### PR TITLE
add simple light shaders, compatible to GLES 2.0

### DIFF
--- a/RetroArch/.retroarch/shaders/TV.glslp
+++ b/RetroArch/.retroarch/shaders/TV.glslp
@@ -1,0 +1,5 @@
+shaders = "1"
+
+feedback_pass = "0"
+shader0 = "shaders/TV.glsl"
+filter_linear0 = "true"

--- a/RetroArch/.retroarch/shaders/blurry.glslp
+++ b/RetroArch/.retroarch/shaders/blurry.glslp
@@ -1,0 +1,4 @@
+shaders = 1
+
+shader0 = "shaders/stock.glsl"
+filter_linear0 = true

--- a/RetroArch/.retroarch/shaders/gritty.glslp
+++ b/RetroArch/.retroarch/shaders/gritty.glslp
@@ -1,0 +1,5 @@
+shaders = "1"
+
+feedback_pass = "0"
+shader0 = "shaders/gritty.glsl"
+filter_linear0 = "true"

--- a/RetroArch/.retroarch/shaders/medium.glslp
+++ b/RetroArch/.retroarch/shaders/medium.glslp
@@ -1,0 +1,4 @@
+shaders = 1
+
+shader0 = "shaders/quilez.glsl"
+filter_linear0 = true

--- a/RetroArch/.retroarch/shaders/non-filtered.glslp
+++ b/RetroArch/.retroarch/shaders/non-filtered.glslp
@@ -1,0 +1,4 @@
+shaders = 1
+
+shader0 = "shaders/stock.glsl"
+filter_linear0 = false

--- a/RetroArch/.retroarch/shaders/shaders/TV.glsl
+++ b/RetroArch/.retroarch/shaders/shaders/TV.glsl
@@ -1,6 +1,6 @@
 #version 110
 
-#pragma parameter scan "Scanlines scale" 2.0 1.0 8.0 1.0
+#pragma parameter scan "Scanlines scale" 2.0 1.0 6.0 0.5
 
 #define PI   3.14159265358979323846
 #define tau  6.283185

--- a/RetroArch/.retroarch/shaders/shaders/TV.glsl
+++ b/RetroArch/.retroarch/shaders/shaders/TV.glsl
@@ -52,7 +52,7 @@ uniform COMPAT_PRECISION float size;
 void main()
 {
     gl_Position = MVPMatrix * VertexCoord;
-    TEX0.xy = TexCoord.xy;
+    TEX0.xy = TexCoord.xy*1.0001;
     ogl2pos = TEX0.xy*SourceSize.xy;
 }
 

--- a/RetroArch/.retroarch/shaders/shaders/TV.glsl
+++ b/RetroArch/.retroarch/shaders/shaders/TV.glsl
@@ -110,7 +110,7 @@ float quil = (near + 4.0*n*n*n)*SourceSize.w;
 vec2 pos = vec2(vTexCoord.x,quil);
 
 vec3 res = COMPAT_TEXTURE(Source,pos).rgb;
-res *= 0.2*sin(vTexCoord.y*480.0*scan)+0.8;
+res *= 0.2*sin(vTexCoord.y*480.0*PI*scan)+0.8;
 FragColor.rgb = res;
 }
 #endif

--- a/RetroArch/.retroarch/shaders/shaders/TV.glsl
+++ b/RetroArch/.retroarch/shaders/shaders/TV.glsl
@@ -1,0 +1,114 @@
+#version 110
+
+#define PI   3.14159265358979323846
+#define tau  6.283185
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+COMPAT_VARYING vec4 COL0;
+COMPAT_VARYING vec4 TEX0;
+COMPAT_VARYING vec2 ogl2pos;
+
+vec4 _oPosition1; 
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+// compatibility #defines
+#define vTexCoord TEX0.xy
+#define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
+#define OutSize vec4(OutputSize, 1.0 / OutputSize)
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float size;
+#else
+#define size 0.0
+#endif
+
+void main()
+{
+    gl_Position = MVPMatrix * VertexCoord;
+    TEX0.xy = TexCoord.xy;
+    ogl2pos = TEX0.xy*SourceSize.xy;
+}
+
+#elif defined(FRAGMENT)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+COMPAT_VARYING vec4 TEX0;
+COMPAT_VARYING vec2 ogl2pos;
+
+// compatibility #defines
+#define vTexCoord TEX0.xy
+#define Source Texture
+#define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
+#define OutSize vec4(OutputSize, 1.0 / OutputSize)
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float sharpness;
+
+#else
+#define sharpness 0.0
+
+#endif
+
+void main() 
+{
+float near = floor(ogl2pos.y)+0.5;
+float n    = ogl2pos.y - near;   
+float quil = (near + 4.0*n*n*n)*SourceSize.w;    
+vec2 pos = vec2(vTexCoord.x,quil);
+
+vec3 res = COMPAT_TEXTURE(Source,pos).rgb;
+res *= 0.2*sin(vTexCoord.y*480.0*PI)+0.8;
+FragColor.rgb = res;
+}
+#endif

--- a/RetroArch/.retroarch/shaders/shaders/TV.glsl
+++ b/RetroArch/.retroarch/shaders/shaders/TV.glsl
@@ -1,5 +1,7 @@
 #version 110
 
+#pragma parameter scan "Scanlines scale" 2.0 1.0 8.0 1.0
+
 #define PI   3.14159265358979323846
 #define tau  6.283185
 
@@ -93,10 +95,10 @@ COMPAT_VARYING vec2 ogl2pos;
 #define OutSize vec4(OutputSize, 1.0 / OutputSize)
 
 #ifdef PARAMETER_UNIFORM
-uniform COMPAT_PRECISION float sharpness;
+uniform COMPAT_PRECISION float scan;
 
 #else
-#define sharpness 0.0
+#define scan 0.0
 
 #endif
 
@@ -108,7 +110,7 @@ float quil = (near + 4.0*n*n*n)*SourceSize.w;
 vec2 pos = vec2(vTexCoord.x,quil);
 
 vec3 res = COMPAT_TEXTURE(Source,pos).rgb;
-res *= 0.2*sin(vTexCoord.y*480.0*PI)+0.8;
+res *= 0.2*sin(vTexCoord.y*480.0*scan)+0.8;
 FragColor.rgb = res;
 }
 #endif

--- a/RetroArch/.retroarch/shaders/shaders/gritty.glsl
+++ b/RetroArch/.retroarch/shaders/shaders/gritty.glsl
@@ -1,0 +1,114 @@
+#version 110
+
+#define PI   3.14159265358979323846
+#define tau  6.283185
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+COMPAT_VARYING vec4 COL0;
+COMPAT_VARYING vec4 TEX0;
+COMPAT_VARYING vec2 ogl2pos;
+
+vec4 _oPosition1; 
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+// compatibility #defines
+#define vTexCoord TEX0.xy
+#define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
+#define OutSize vec4(OutputSize, 1.0 / OutputSize)
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float size;
+#else
+#define size 0.0
+#endif
+
+void main()
+{
+    gl_Position = MVPMatrix * VertexCoord;
+    TEX0.xy = TexCoord.xy;
+    ogl2pos = TEX0.xy*SourceSize.xy;
+}
+
+#elif defined(FRAGMENT)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+COMPAT_VARYING vec4 TEX0;
+COMPAT_VARYING vec2 ogl2pos;
+
+// compatibility #defines
+#define vTexCoord TEX0.xy
+#define Source Texture
+#define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
+#define OutSize vec4(OutputSize, 1.0 / OutputSize)
+
+#ifdef PARAMETER_UNIFORM
+uniform COMPAT_PRECISION float sharpness;
+
+#else
+#define sharpness 0.0
+
+#endif
+
+void main() 
+{
+float near = floor(ogl2pos.y)+0.5;
+float n    = ogl2pos.y - near;   
+float quil = (near + 4.0*n*n*n)*SourceSize.w;    
+vec2 pos = vec2(vTexCoord.x,quil);
+
+vec3 res = COMPAT_TEXTURE(Source,pos).rgb;
+
+FragColor.rgb = res;
+}
+#endif

--- a/RetroArch/.retroarch/shaders/shaders/quilez.glsl
+++ b/RetroArch/.retroarch/shaders/shaders/quilez.glsl
@@ -1,0 +1,103 @@
+/*
+	Fragment shader based on "Improved texture interpolation" by Iñigo Quílez
+	Original description: http://www.iquilezles.org/www/articles/texture/texture.htm
+*/
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+COMPAT_VARYING vec4 COL0;
+COMPAT_VARYING vec4 TEX0;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+// vertex compatibility #defines
+#define vTexCoord TEX0.xy
+#define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
+#define outsize vec4(OutputSize, 1.0 / OutputSize)
+
+void main()
+{
+    gl_Position = MVPMatrix * VertexCoord;
+    COL0 = COLOR;
+    TEX0.xy = TexCoord.xy;
+}
+
+#elif defined(FRAGMENT)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+COMPAT_VARYING vec4 TEX0;
+
+// fragment compatibility #defines
+#define Source Texture
+#define vTexCoord TEX0.xy
+
+#define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
+#define outsize vec4(OutputSize, 1.0 / OutputSize)
+
+void main()
+{
+	vec2 p = vTexCoord.xy;
+
+	p = p * SourceSize.xy + vec2(0.5, 0.5);
+
+	vec2 i = floor(p);
+	vec2 f = p - i;
+	f = f * f * f * (f * (f * 6.0 - vec2(15.0, 15.0)) + vec2(10.0, 10.0));
+	p = i + f;
+
+	p = (p - vec2(0.5, 0.5)) * SourceSize.zw;
+
+	// final sum and weight normalization
+   FragColor = vec4(COMPAT_TEXTURE(Source, p));
+} 
+#endif

--- a/RetroArch/.retroarch/shaders/shaders/sharp-bilinear-simple.glsl
+++ b/RetroArch/.retroarch/shaders/shaders/sharp-bilinear-simple.glsl
@@ -1,0 +1,123 @@
+/*
+   Author: rsn8887 (based on TheMaister)
+   License: Public domain
+
+   This is an integer prescale filter that should be combined
+   with a bilinear hardware filtering (GL_BILINEAR filter or some such) to achieve
+   a smooth scaling result with minimum blur. This is good for pixelgraphics
+   that are scaled by non-integer factors.
+   
+   The prescale factor and texel coordinates are precalculated
+   in the vertex shader for speed.
+*/
+
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+COMPAT_VARYING vec4 COL0;
+COMPAT_VARYING vec4 TEX0;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+// vertex compatibility #defines
+#define vTexCoord TEX0.xy
+#define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
+#define outsize vec4(OutputSize, 1.0 / OutputSize)
+
+COMPAT_VARYING vec2 precalc_texel;
+COMPAT_VARYING vec2 precalc_scale;
+
+void main()
+{
+    gl_Position = MVPMatrix * VertexCoord;
+    COL0 = COLOR;
+    TEX0.xy = TexCoord.xy;
+
+    precalc_texel = vTexCoord * SourceSize.xy;
+    precalc_scale = max(floor(outsize.xy / InputSize.xy), vec2(1.0, 1.0));
+}
+
+#elif defined(FRAGMENT)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+COMPAT_VARYING vec4 TEX0;
+
+// fragment compatibility #defines
+#define Source Texture
+#define vTexCoord TEX0.xy
+
+#define SourceSize vec4(TextureSize, 1.0 / TextureSize) //either TextureSize or InputSize
+#define outsize vec4(OutputSize, 1.0 / OutputSize)
+
+COMPAT_VARYING vec2 precalc_texel;
+COMPAT_VARYING vec2 precalc_scale;
+
+void main()
+{
+   vec2 texel = precalc_texel;
+   vec2 scale = precalc_scale;
+
+   vec2 texel_floored = floor(texel);
+   vec2 s = fract(texel);
+   vec2 region_range = 0.5 - 0.5 / scale;
+
+   // Figure out where in the texel to sample to get correct pre-scaled bilinear.
+   // Uses the hardware bilinear interpolator to avoid having to sample 4 times manually.
+
+   vec2 center_dist = s - 0.5;
+   vec2 f = (center_dist - clamp(center_dist, -region_range, region_range)) * scale + 0.5;
+
+   vec2 mod_texel = texel_floored + f;
+
+   FragColor = vec4(COMPAT_TEXTURE(Source, mod_texel / SourceSize.xy).rgb, 1.0);
+} 
+#endif

--- a/RetroArch/.retroarch/shaders/shaders/stock.glsl
+++ b/RetroArch/.retroarch/shaders/shaders/stock.glsl
@@ -1,0 +1,73 @@
+#if defined(VERTEX)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+COMPAT_ATTRIBUTE vec4 VertexCoord;
+COMPAT_ATTRIBUTE vec4 COLOR;
+COMPAT_ATTRIBUTE vec4 TexCoord;
+COMPAT_VARYING vec4 COL0;
+COMPAT_VARYING vec4 TEX0;
+
+uniform mat4 MVPMatrix;
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+
+void main()
+{
+    gl_Position = VertexCoord.x * MVPMatrix[0] + VertexCoord.y * MVPMatrix[1] + VertexCoord.z * MVPMatrix[2] + VertexCoord.w * MVPMatrix[3];
+    TEX0.xy = TexCoord.xy;
+}
+
+#elif defined(FRAGMENT)
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+#ifdef GL_ES
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+#define COMPAT_PRECISION mediump
+#else
+#define COMPAT_PRECISION
+#endif
+
+uniform COMPAT_PRECISION int FrameDirection;
+uniform COMPAT_PRECISION int FrameCount;
+uniform COMPAT_PRECISION vec2 OutputSize;
+uniform COMPAT_PRECISION vec2 TextureSize;
+uniform COMPAT_PRECISION vec2 InputSize;
+uniform sampler2D Texture;
+COMPAT_VARYING vec4 TEX0;
+
+void main()
+{
+    FragColor = COMPAT_TEXTURE(Texture, TEX0.xy);
+} 
+#endif

--- a/RetroArch/.retroarch/shaders/sharp.glslp
+++ b/RetroArch/.retroarch/shaders/sharp.glslp
@@ -1,0 +1,4 @@
+shaders = 1
+
+shader0 = "shaders/sharp-bilinear-simple.glsl"
+filter_linear0 = true


### PR DESCRIPTION
They work fine on my A30, full speed easily. They can resolve the nasty scaling when full screen (without resolution being an exact multiply). With these you can occupy all screen on gba, gb, gbc, gg, snes without nasty bad scaling artifacts.

Moved all presets to one folder for new users ease of life and readability