### PR TITLE
Change default core for Game Gear/Master System to Genesis Plus GX

### DIFF
--- a/Emu/.emu_setup/core/gearsystem.sh
+++ b/Emu/.emu_setup/core/gearsystem.sh
@@ -4,6 +4,6 @@ EMU_NAME="$(echo "$1" | cut -d'/' -f5)"
 CONFIG="/mnt/SDCARD/Emu/${EMU_NAME}/config.json"
 SYS_OPT="/mnt/SDCARD/Emu/.emu_setup/options/${EMU_NAME}.opt"
 
-sed -i 's|"Emu Core: gearsystem-picodrive-(✓GENESIS+GX)"|"Emu Core: (✓GEARSYSTEM)-picodrive-genesis+gx"|g' "$CONFIG"
-sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/gearsystem.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/picodrive.sh"|g' "$CONFIG"
+sed -i 's|"Emu Core: genesis+gx-(✓PICODRIVE)-gearsystem"|"Emu Core: genesis+gx-picodrive-(✓GEARSYSTEM)"|g' "$CONFIG"
+sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/gearsystem.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/genesis_plus_gx.sh"|g' "$CONFIG"
 sed -i 's|CORE=.*|CORE=\"gearsystem\"|g' "$SYS_OPT"

--- a/Emu/.emu_setup/core/genesis_plus_gx.sh
+++ b/Emu/.emu_setup/core/genesis_plus_gx.sh
@@ -8,8 +8,8 @@ if [ "$EMU_NAME" = "MD" ] || [ "$EMU_NAME" = "SEGACD" ] || [ "$EMU_NAME" = "THIR
     sed -i 's|"Emu Core: (✓PICODRIVE)-genesis+gx"|"Emu Core: picodrive-(✓GENESIS+GX)"|g' "$CONFIG"
     sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/genesis_plus_gx.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/picodrive.sh"|g' "$CONFIG"
 else
-    sed -i 's|"Emu Core: gearsystem-(✓PICODRIVE)-genesis+gx"|"Emu Core: gearsystem-picodrive-(✓GENESIS+GX)"|g' "$CONFIG"
-    sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/genesis_plus_gx.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/gearsystem.sh"|g' "$CONFIG"
+    sed -i 's|"Emu Core: genesis+gx-picodrive-(✓GEARSYSTEM)"|"Emu Core: (✓GENESIS+GX)-picodrive-gearsystem"|g' "$CONFIG"
+    sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/genesis_plus_gx.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/picodrive.sh"|g' "$CONFIG"
 fi
 
 sed -i 's|CORE=.*|CORE=\"genesis_plus_gx\"|g' "$SYS_OPT"

--- a/Emu/.emu_setup/core/picodrive.sh
+++ b/Emu/.emu_setup/core/picodrive.sh
@@ -6,9 +6,10 @@ SYS_OPT="/mnt/SDCARD/Emu/.emu_setup/options/${EMU_NAME}.opt"
 
 if [ "$EMU_NAME" = "MD" ] || [ "$EMU_NAME" = "SEGACD" ] || [ "$EMU_NAME" = "THIRTYTWOX" ]; then
     sed -i 's|"Emu Core: picodrive-(✓GENESIS+GX)"|"Emu Core: (✓PICODRIVE)-genesis+gx"|g' "$CONFIG"
+    sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/picodrive.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/genesis_plus_gx.sh"|g' "$CONFIG"
 else
-    sed -i 's|"Emu Core: (✓GEARSYSTEM)-picodrive-genesis+gx"|"Emu Core: gearsystem-(✓PICODRIVE)-genesis+gx"|g' "$CONFIG"
+    sed -i 's|"Emu Core: (✓GENESIS+GX)-picodrive-gearsystem"|"Emu Core: genesis+gx-(✓PICODRIVE)-gearsystem"|g' "$CONFIG"
+    sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/picodrive.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/gearsystem.sh"|g' "$CONFIG"
 fi
 
-sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/picodrive.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/genesis_plus_gx.sh"|g' "$CONFIG"
 sed -i 's|CORE=.*|CORE=\"picodrive\"|g' "$SYS_OPT"

--- a/Emu/.emu_setup/defaults/GG.opt
+++ b/Emu/.emu_setup/defaults/GG.opt
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export CORE="gearsystem"
+export CORE="genesis_plus_gx"
 export MODE="smart"
 
 export scaling_min_freq=408000

--- a/Emu/.emu_setup/defaults/MS.opt
+++ b/Emu/.emu_setup/defaults/MS.opt
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export CORE="gearsystem"
+export CORE="genesis_plus_gx"
 export MODE="smart"
 
-export scaling_min_freq=480000
+export scaling_min_freq=408000

--- a/Emu/GG/config.json
+++ b/Emu/GG/config.json
@@ -16,7 +16,7 @@
       "launch": "/mnt/SDCARD/Emu/.emu_setup/aleatorio.sh"
     },
     {
-      "name": "Emu Core: (✓GEARSYSTEM)-picodrive-genesis+gx",
+      "name": "Emu Core: (✓GENESIS+GX)-picodrive-gearsystem",
       "launch": "/mnt/SDCARD/Emu/.emu_setup/core/picodrive.sh"
     },
     {

--- a/Emu/MS/config.json
+++ b/Emu/MS/config.json
@@ -16,7 +16,7 @@
       "launch": "/mnt/SDCARD/Emu/.emu_setup/aleatorio.sh"
     },
     {
-      "name": "Emu Core: (✓GEARSYSTEM)-picodrive-genesis+gx",
+      "name": "Emu Core: (✓GENESIS+GX)-picodrive-gearsystem",
       "launch": "/mnt/SDCARD/Emu/.emu_setup/core/picodrive.sh"
     },
     {


### PR DESCRIPTION
The Gearsystem core uses a lot of CPU compared to both PicoDrive and Genesis Plus GX when emulating the Master System and Game Gear: from my testing, while operating under the smart CPU mode, Gearsystem runs at 1008MHz , whereas both Picodrive and Genesis Plus GX run at 480MHz. 

I've decided to change to Genesis Plus GX instead of Picodrive as it provides a good middleground between accuracy and performance.