### PR TITLE
Protect governor from miyoo

### DIFF
--- a/spruce/scripts/enforceSmartCPU.sh
+++ b/spruce/scripts/enforceSmartCPU.sh
@@ -2,11 +2,13 @@
 
 . "/mnt/SDCARD/spruce/scripts/helperFunctions.sh"
 GOVERNOR_FILE="/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"
-while true; do
-	sleep 10
-	governor="$(cat "$GOVERNOR_FILE")"
-    if [ "$governor" != "conservative" ]; then
-		log_message "CPU governor has changed. Re-enforcing SMART mode"
-		set_smart
-    fi
-done
+sleep 10
+governor="$(cat "$GOVERNOR_FILE")"
+if [ "$governor" != "conservative" ]; then
+	# lock menu button to prevent ra32 menu from changing governor before we can lock out its write permission
+	killall -19 getevent
+	log_message "CPU governor is not set to conservative. Re-enforcing SMART mode"
+	set_smart
+	# re-enable menu button now that ra32 can't reset the governor
+	killall -18 getevent 
+fi

--- a/spruce/scripts/helperFunctions.sh
+++ b/spruce/scripts/helperFunctions.sh
@@ -623,6 +623,7 @@ log_precise() {
 scaling_min_freq=1008000 ### default value, may be overridden in specific script
 set_smart() {
 	cores_online
+    chmod a+w /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 	echo conservative > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 	echo 30 > /sys/devices/system/cpu/cpufreq/conservative/down_threshold
 	echo 70 > /sys/devices/system/cpu/cpufreq/conservative/up_threshold
@@ -630,19 +631,24 @@ set_smart() {
 	echo 1 > /sys/devices/system/cpu/cpufreq/conservative/sampling_down_factor
 	echo 400000 > /sys/devices/system/cpu/cpufreq/conservative/sampling_rate
 	echo "$scaling_min_freq" > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
-	log_message "CPU Mode set to SMART" -v
+    chmod a-w /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+	log_message "CPU Mode now locked to SMART" -v
 }
 
 set_performance() {
+	cores_online
+    chmod a+w /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 	echo performance > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
-	log_message "CPU Mode set to PERFORMANCE" -v
+    chmod a-w /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+	log_message "CPU Mode now locked to PERFORMANCE" -v
 
 }
 
 set_overclock() {
+    chmod a+w /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 	/mnt/SDCARD/miyoo/utils/utils "performance" 4 1512 384 1080 1
-	log_message "CPU Mode set to OVERCLOCK" -v
-
+    chmod a-w /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+	log_message "CPU Mode now locked to OVERCLOCK" -v
 }
 
 

--- a/spruce/scripts/helperFunctions.sh
+++ b/spruce/scripts/helperFunctions.sh
@@ -620,7 +620,6 @@ log_precise() {
     printf '%s %s\n' "$timestamp" "$message" >> "$log_file"
 }
 
-scaling_min_freq=1008000 ### default value, may be overridden in specific script
 set_smart() {
 	cores_online
     chmod a+w /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor

--- a/spruce/scripts/principal.sh
+++ b/spruce/scripts/principal.sh
@@ -91,6 +91,7 @@ while [ 1 ]; do
         rm /tmp/cmd_to_run.sh
 
         # reset CPU settings to defaults in case an emulator changes anything
+        scaling_min_freq=1008000 ### default value, may be overridden in specific script
         set_smart &
     fi
 

--- a/spruce/scripts/runtime.sh
+++ b/spruce/scripts/runtime.sh
@@ -146,6 +146,7 @@ ${SCRIPTS_DIR}/checkfaves.sh &
 ${SCRIPTS_DIR}/credits_watchdog.sh &
 
 # Initialize CPU settings
+scaling_min_freq=1008000 ### default value, may be overridden in specific script
 set_smart
 
 # start main loop


### PR DESCRIPTION
The in-game menu built into ra32.miyoo will no longer have any control over the cpu speed or governor. This has been accomplished by only enabling write permissions to the cpu governor virtual file during one of the three set_<mode> helper functions.