### PR TITLE
Syncthing  make sync check compatible with disabled network options

### DIFF
--- a/Emu/.emu_setup/standard_launch.sh
+++ b/Emu/.emu_setup/standard_launch.sh
@@ -61,6 +61,7 @@ fi
 
 wifi_needed=false
 syncthing_enabled=false
+wifi_connected=false
 
 ##### RAC Check
 if grep -q 'cheevos_enable = "true"' /mnt/SDCARD/RetroArch/retroarch.cfg; then
@@ -70,38 +71,36 @@ fi
 
 ##### Syncthing Sync Check, perform only once per session #####
 if setting_get "syncthing" && ! flag_check "syncthing_startup_synced"; then
-	log_message "Syncthing is enabled, WiFi connection needed"
-	wifi_needed=true
-	syncthing_enabled=true
+    log_message "Syncthing is enabled, WiFi connection needed"
+    wifi_needed=true
+    syncthing_enabled=true
 fi
 
-if setting_get "disableNetworkServicesInGame" || setting_get "disableWifiInGame"; then
-    
-	/mnt/SDCARD/spruce/scripts/networkservices.sh off &
-	
-	if setting_get "disableWifiInGame"; then
-		
-		if ifconfig wlan0 | grep "inet addr:" >/dev/null 2>&1; then
-			ifconfig wlan0 down &
-		fi
-  
-		killall wpa_supplicant
-		killall udhcpc
-	fi
-else
-    if $syncthing_enabled; then
-        if check_and_connect_wifi; then
-            start_syncthing_process
-            /mnt/SDCARD/spruce/bin/Syncthing/syncthing_sync_check.sh --startup
-            flag_add "syncthing_startup_synced"
-        else
-            log_message "Failed to connect to WiFi, skipping Sync check"
-        fi
+# Connect to WiFi if needed for any service
+if $wifi_needed; then
+    if check_and_connect_wifi; then
+        wifi_connected=true
     fi
 fi
 
-if $wifi_needed && ! setting_get "disableWifiInGame"; then
-    check_and_connect_wifi
+# Handle Syncthing sync if enabled
+if $syncthing_enabled && $wifi_connected; then
+    start_syncthing_process
+    /mnt/SDCARD/spruce/bin/Syncthing/syncthing_sync_check.sh --startup
+    flag_add "syncthing_startup_synced"
+fi
+
+# Handle network service disabling
+if setting_get "disableNetworkServicesInGame" || setting_get "disableWifiInGame"; then
+    /mnt/SDCARD/spruce/scripts/networkservices.sh off &
+    
+    if setting_get "disableWifiInGame"; then
+        if ifconfig wlan0 | grep "inet addr:" >/dev/null 2>&1; then
+            ifconfig wlan0 down &
+        fi
+        killall wpa_supplicant
+        killall udhcpc
+    fi
 fi
 
 flag_add 'emulator_launched'

--- a/spruce/bin/Syncthing/syncthingFunctions.sh
+++ b/spruce/bin/Syncthing/syncthingFunctions.sh
@@ -7,6 +7,11 @@ SYNCTHING_DIR=/mnt/SDCARD/spruce/bin/Syncthing
 # Generic Statup
 # Should only be used in contexts where firststart has already been called
 start_syncthing_process(){
+    if pgrep "syncthing" >/dev/null; then
+        log_message "Syncthing: Already running, skipping start"
+        return
+    fi
+    
     log_message "Syncthing: Starting Syncthing..."
     $SYNCTHING_DIR/bin/syncthing serve --home=$SYNCTHING_DIR/config/ > $SYNCTHING_DIR/serve.log 2>&1 &
 }

--- a/spruce/bin/Syncthing/syncthing_sync_check.sh
+++ b/spruce/bin/Syncthing/syncthing_sync_check.sh
@@ -167,18 +167,24 @@ Press START to cancel" -i "$BG_TREE"
     if [ "$mode" = "shutdown" ]; then
         force_rescan
         sleep 2
-    elif [ "$mode" = "startup" ]; then
-        force_rediscovery
-        # Give a few seconds for forced discovery to trigger a rescan
-        sleep 4
     fi
 
-    # Check if any devices are online
+    # Always force rediscovery in case service was not running
+    force_rediscovery
+
+    # Give a few seconds for forced discovery to trigger a rescan
+    sleep 5
+
     if ! are_devices_online; then
-        log_message "SyncthingCheck: No devices are online. Exiting sync check."
-        display -t "No devices online" -i "$BG_TREE"
-        sleep 1
-        return 1
+        log_message "SyncthingCheck: No devices found on first attempt, waiting for second attempt..."
+        sleep 2
+        # Second attempt
+        if ! are_devices_online; then
+            log_message "SyncthingCheck: No devices are online after retry. Exiting sync check."
+            display -t "No devices online" -i "$BG_TREE"
+            sleep 1
+            return 1
+        fi
     fi
 
     while true; do
@@ -287,8 +293,6 @@ main() {
             else
                 display -t "Failed to connect to Syncthing API" -i "$BG_TREE"
                 sleep 1
-                stop_network
-                exit 1
             fi
             ;;
         --shutdown)
@@ -296,9 +300,13 @@ main() {
             killall -9 MainUI
             killall -9 principal.sh
 
-            # Add a similar wait_for_syncthing_api function if this proves to cause troubles
-            # Ideally this is not needed on shutdown as the API is already available
-            monitor_sync_status "shutdown"
+            if wait_for_syncthing_api; then
+                monitor_sync_status "shutdown"
+            else
+                display -t "Failed to connect to Syncthing API" -i "$BG_TREE"
+                sleep 1
+            fi
+
             killall -9 syncthing
             ;;
         *)

--- a/spruce/scripts/save_poweroff.sh
+++ b/spruce/scripts/save_poweroff.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 . /mnt/SDCARD/spruce/scripts/helperFunctions.sh
+. /mnt/SDCARD/spruce/bin/Syncthing/syncthingFunctions.sh
 
 BIN_PATH="/mnt/SDCARD/spruce/bin"
 FLAGS_DIR="/mnt/SDCARD/spruce/flags"
@@ -141,6 +142,7 @@ if setting_get "syncthing" && flag_check "emulator_launched"; then
 	log_message "Syncthing is enabled, WiFi connection needed"
 
 	if check_and_connect_wifi; then
+		start_syncthing_process
 		# Dimming screen before syncthing sync check
 		dim_screen &
 		/mnt/SDCARD/spruce/bin/Syncthing/syncthing_sync_check.sh --shutdown


### PR DESCRIPTION
### Problem

Before, `Syncthing Sync Check` did not work if you have `Disable Network Services in Game` or `Disable Wifi in Game`

The Sync would be skipped on RA Launch and would fail on RA Shutdown for a few reasons, but the TLDR is I wrote the checker with assumptions on startup/shutdown that aren't true anymore because of these new options.

### Latest Major Changes
* Run Sync Checker BEFORE we disable network services or wifi.
* Ensure we always start the Syncthing process if it isn't running when needed in `startup` and in `shutdown`



