### PR TITLE
Expose quicknes core to UI

### DIFF
--- a/Emu/.emu_setup/core/fceumm.sh
+++ b/Emu/.emu_setup/core/fceumm.sh
@@ -10,12 +10,11 @@ display -i "$BG" -t "Core changed to fceumm"
 
 if [ "$EMU_NAME" = "FC" ]; then
     sed -i 's|"Emu Core: fceumm-(✓NESTOPIA)-quicknes"|"Emu Core: (✓FCEUMM)-nestopia-quicknes"|g' "$CONFIG"
-    sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/fceumm.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/nestopia.sh"|g' "$CONFIG"
 elif [ "$EMU_NAME" = "FDS" ]; then
     sed -i 's|"Emu Core: fceumm-(✓NESTOPIA)"|"Emu Core: (✓FCEUMM)-nestopia"|g' "$CONFIG"
-    sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/fceumm.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/nestopia.sh"|g' "$CONFIG"
 fi
 
+sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/fceumm.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/nestopia.sh"|g' "$CONFIG"
 sed -i 's|CORE=.*|CORE=\"fceumm\"|g' "$SYS_OPT"
 
 sleep 2

--- a/Emu/.emu_setup/core/fceumm.sh
+++ b/Emu/.emu_setup/core/fceumm.sh
@@ -8,8 +8,14 @@ SYS_OPT="/mnt/SDCARD/Emu/.emu_setup/options/${EMU_NAME}.opt"
 
 display -i "$BG" -t "Core changed to fceumm"
 
-sed -i 's|"Emu Core: fceumm-(✓NESTOPIA)"|"Emu Core: (✓FCEUMM)-nestopia"|g' "$CONFIG"
-sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/fceumm.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/nestopia.sh"|g' "$CONFIG"
+if [ "$EMU_NAME" = "FC" ]; then
+    sed -i 's|"Emu Core: fceumm-(✓NESTOPIA)-quicknes"|"Emu Core: (✓FCEUMM)-nestopia-quicknes"|g' "$CONFIG"
+    sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/fceumm.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/nestopia.sh"|g' "$CONFIG"
+elif [ "$EMU_NAME" = "FDS" ]; then
+    sed -i 's|"Emu Core: fceumm-(✓NESTOPIA)"|"Emu Core: (✓FCEUMM)-nestopia"|g' "$CONFIG"
+    sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/fceumm.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/nestopia.sh"|g' "$CONFIG"
+fi
+
 sed -i 's|CORE=.*|CORE=\"fceumm\"|g' "$SYS_OPT"
 
 sleep 2

--- a/Emu/.emu_setup/core/nestopia.sh
+++ b/Emu/.emu_setup/core/nestopia.sh
@@ -8,8 +8,14 @@ SYS_OPT="/mnt/SDCARD/Emu/.emu_setup/options/${EMU_NAME}.opt"
 
 display -i "$BG" -t "Core changed to nestopia"
 
-sed -i 's|"Emu Core: (✓FCEUMM)-nestopia"|"Emu Core: fceumm-(✓NESTOPIA)"|g' "$CONFIG"
-sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/nestopia.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/fceumm.sh"|g' "$CONFIG"
+if [ "$EMU_NAME" = "FC" ]; then
+    sed -i 's|"Emu Core: (✓FCEUMM)-nestopia-quicknes"|"Emu Core: fceumm-(✓NESTOPIA)-quicknes"|g' "$CONFIG"
+    sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/nestopia.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/quicknes.sh"|g' "$CONFIG"
+elif [ "$EMU_NAME" = "FDS" ]; then
+    sed -i 's|"Emu Core: (✓FCEUMM)-nestopia"|"Emu Core: fceumm-(✓NESTOPIA)"|g' "$CONFIG"
+    sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/nestopia.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/fceumm.sh"|g' "$CONFIG"
+fi
+
 sed -i 's|CORE=.*|CORE=\"nestopia\"|g' "$SYS_OPT"
 
 sleep 2

--- a/Emu/.emu_setup/core/quicknes.sh
+++ b/Emu/.emu_setup/core/quicknes.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+. /mnt/SDCARD/spruce/scripts/helperFunctions.sh
+BG="/mnt/SDCARD/spruce/imgs/bg_tree.png"
+EMU_NAME="$(echo "$1" | cut -d'/' -f5)"
+CONFIG="/mnt/SDCARD/Emu/${EMU_NAME}/config.json"
+SYS_OPT="/mnt/SDCARD/Emu/.emu_setup/options/${EMU_NAME}.opt"
+
+display -i "$BG" -t "Core changed to quicknes"
+
+sed -i 's|"Emu Core: fceumm-(✓NESTOPIA)-quicknes"|"Emu Core: fceumm-nestopia-(✓QUICKNES)"|g' "$CONFIG"
+sed -i 's|"/mnt/SDCARD/Emu/.emu_setup/core/quicknes.sh"|"/mnt/SDCARD/Emu/.emu_setup/core/fceumm.sh"|g' "$CONFIG"
+sed -i 's|CORE=.*|CORE=\"quicknes\"|g' "$SYS_OPT"
+
+sleep 2
+display_kill

--- a/Emu/.emu_setup/defaults/FC.opt
+++ b/Emu/.emu_setup/defaults/FC.opt
@@ -3,4 +3,4 @@
 export CORE="fceumm"
 export MODE="smart"
 
-export scaling_min_freq=408000
+export scaling_min_freq=312000

--- a/Emu/FC/config.json
+++ b/Emu/FC/config.json
@@ -16,7 +16,7 @@
       "launch": "/mnt/SDCARD/Emu/.emu_setup/aleatorio.sh"
     },
     {
-      "name": "Emu Core: (✓FCEUMM)-nestopia",
+      "name": "Emu Core: (✓FCEUMM)-nestopia-quicknes",
       "launch": "/mnt/SDCARD/Emu/.emu_setup/core/nestopia.sh"
     },
     {


### PR DESCRIPTION
Quicknes, a very, very fast NES emulation core that should be much easier on the A30's CPU and battery (it's about 3x faster than FCEUMM with fast forward testing). 4 games are broken due to lack of mapper support, which is documented [here](https://docs.libretro.com/library/fceumm/)