### PR TITLE
ST Sync Check:  Make faster and more robust

### DIFF
--- a/Emu/.emu_setup/standard_launch.sh
+++ b/Emu/.emu_setup/standard_launch.sh
@@ -82,11 +82,12 @@ if $syncthing_enabled && $wifi_connected; then
     start_syncthing_process
     /mnt/SDCARD/spruce/bin/Syncthing/syncthing_sync_check.sh --startup
     flag_add "syncthing_startup_synced"
+
 fi
 
 # Handle network service disabling
 if setting_get "disableNetworkServicesInGame" || setting_get "disableWifiInGame"; then
-    /mnt/SDCARD/spruce/scripts/networkservices.sh off &
+    /mnt/SDCARD/spruce/scripts/networkservices.sh off
     
     if setting_get "disableWifiInGame"; then
         if ifconfig wlan0 | grep "inet addr:" >/dev/null 2>&1; then

--- a/spruce/scripts/networkservices.sh
+++ b/spruce/scripts/networkservices.sh
@@ -7,7 +7,10 @@
 
 connect_services() {
     
-    while ! ifconfig wlan0 | grep -qE "inet |inet6 "; do
+	while true; do
+        if ifconfig wlan0 | grep -qE "inet |inet6 " && ping -c 1 -W 3 1.1.1.1 >/dev/null 2>&1; then
+            break
+        fi
         sleep 0.5
     done
 	  


### PR DESCRIPTION
### Problem
ST Sync Check was using long static sleeps and always assumed worse case scenario. This meant punishing everyone even if they kept their Wifi and Network services enabled in game.

Also due to how we kill network services in game, we sometimes put ST in a broken state when wifi/wlan would get killed before ST shuts down

### Solution
* Ensure we kill network services in the foreground so ST exits gracefully and isn't put in a broken state due to a race condition with wifi/wlan
* Use polling mechanisms to ensure that script works for all types of possible toggles, such as `Disable Network Services in Game` and `Disable Wifi in Game` 
