### PR TITLE
feat(multipass): add marking hidden network in multipass

### DIFF
--- a/multipass.cfg
+++ b/multipass.cfg
@@ -18,15 +18,20 @@
 
 ID_1=""
 PW_1=""
+HIDDEN_1=""
 
 ID_2=""
 PW_2=""
+HIDDEN_2=""
 
 ID_3=""
 PW_3=""
+HIDDEN_3=""
 
 ID_4=""
 PW_4=""
+HIDDEN_4=""
 
 ID_5=""
 PW_5=""
+HIDDEN_5=""

--- a/multipass.cfg
+++ b/multipass.cfg
@@ -3,8 +3,9 @@
 # MULTIPASS.CFG - HOW TO USE:
 #
 # This file provides an optional way to store up to 5 different WiFi networks
-# on your A30. Type the SSID and password of your desired networks inside the
-# quotation marks in each pair below, starting with ID_1 and PW_1.
+# on your A30. Type the SSID, password and hidden status of your desired networks inside the
+# quotation marks in each parameter below, starting with ID_1, PW_1 and HIDDEN_1.
+# HIDDEN_x parameter is "1" for hidden networks and "0" for visible networks.
 #
 # On your next boot, the A30 will interpret this file and convert it into an
 # actual WiFi configuration. Then, this file will delete itself for security

--- a/multipass.cfg
+++ b/multipass.cfg
@@ -5,7 +5,7 @@
 # This file provides an optional way to store up to 5 different WiFi networks
 # on your A30. Type the SSID, password and hidden status of your desired networks inside the
 # quotation marks in each parameter below, starting with ID_1, PW_1 and HIDDEN_1.
-# HIDDEN_x parameter is "1" for hidden networks and "0" for visible networks.
+# HIDDEN_x parameter is "1" for hidden networks and "0" for visible networks and this parameter is optional.
 #
 # On your next boot, the A30 will interpret this file and convert it into an
 # actual WiFi configuration. Then, this file will delete itself for security

--- a/spruce/scripts/wpa_watchdog.sh
+++ b/spruce/scripts/wpa_watchdog.sh
@@ -18,7 +18,7 @@ append_network_from_multipass() {
     echo "ssid=\"$1\""
     echo "psk=\"$2\""
     if [ "$3" = "1" ]; then
-        echo "scan_ssid=\"$3\""
+        echo "scan_ssid=$3"
     fi
     echo "}"
 }

--- a/spruce/scripts/wpa_watchdog.sh
+++ b/spruce/scripts/wpa_watchdog.sh
@@ -17,6 +17,9 @@ append_network_from_multipass() {
     echo "network={"
     echo "ssid=\"$1\""
     echo "psk=\"$2\""
+    if [ "$3" = "1" ]; then
+        echo "scan_ssid=$3"
+    fi
     echo "}"
 }
 
@@ -49,6 +52,7 @@ if [ -f /mnt/SDCARD/multipass.cfg ]; then
     for i in 1 2 3 4 5; do
         eval "ID=\$ID_$i"
         eval "PW=\$PW_$i"
+        eval "HIDDEN=\$HIDDEN_$i"
 
         # SSID and PSK must be non-empty to be evaluated
         if [ -n "$ID" ] && [ -n "$PW" ]; then
@@ -67,7 +71,7 @@ if [ -f /mnt/SDCARD/multipass.cfg ]; then
                 fi
 
             else ### SSID not found in wpa_supplicant.conf, so we add it
-                append_network_from_multipass "$ID" "$PW" >> "$WPA_FILE"
+                append_network_from_multipass "$ID" "$PW" "$HIDDEN" >> "$WPA_FILE"
                 log_message "Network $ID added to wpa_supplicant.conf"
             fi
 

--- a/spruce/scripts/wpa_watchdog.sh
+++ b/spruce/scripts/wpa_watchdog.sh
@@ -18,7 +18,7 @@ append_network_from_multipass() {
     echo "ssid=\"$1\""
     echo "psk=\"$2\""
     if [ "$3" = "1" ]; then
-        echo "scan_ssid=$3"
+        echo "scan_ssid=\"$3\""
     fi
     echo "}"
 }


### PR DESCRIPTION
Allows user to tell if network specified in multipass file is hidden by providing "1" value.

I added reading HIDDEN_1, HIDDEN_2 ...... from multipass and according to its value scan_ssid=1 is added in wpa_supplicant

According to https://wiki.archlinux.org/title/Wpa_supplicant#Connection if the network is hidden, wpa_supplicant should have scan_ssid=1. 