### PR TITLE
feat(ra): exclude PSX when enabling rewind in RetroArch

### DIFF
--- a/spruce/scripts/applySetting/retroArchRewind.sh
+++ b/spruce/scripts/applySetting/retroArchRewind.sh
@@ -1,4 +1,6 @@
 RETROARCH_CFG="/mnt/SDCARD/RetroArch/retroarch.cfg"
+PCSX_CFG="/mnt/SDCARD/RetroArch/.retroarch/config/PCSX-ReARMed/PCSX-ReARMed.cfg"
+SWANSTATION_CFG="/mnt/SDCARD/RetroArch/.retroarch/config/SwanStation/SwanStation.cfg"
 
 if [ "$1" = "check" ]; then
     # Check if all rewind settings match the "On" configuration
@@ -29,19 +31,33 @@ fi
 . /mnt/SDCARD/spruce/scripts/helperFunctions.sh
 
 if [ "$1" = "assign" ]; then
+    pcsx_rewind_present=$(grep '^rewind_enable = ' "$PCSX_CFG")
+    swanstation_rewind_present=$(grep '^rewind_enable = ' "$SWANSTATION_CFG")
     case "$2" in
         "on")
-            log_message "RetroArch hotkey set to Select"
+            log_message "RetroArch Rewind: on"
             sed -i 's/^input_rewind = .*/input_rewind = "e"/' "$RETROARCH_CFG"
             sed -i 's/^input_toggle_slowmotion = .*/input_toggle_slowmotion = "nul"/' "$RETROARCH_CFG"
             sed -i 's/^rewind_enable = .*/rewind_enable = "true"/' "$RETROARCH_CFG"
             sed -i 's/^rewind_granularity = .*/rewind_granularity = "2"/' "$RETROARCH_CFG"
+            if [ -n "$pcsx_rewind_present" ]; then
+              sed -i 's/^rewind_enable = .*/rewind_enable = "false"/' "$PCSX_CFG"
+            else
+              printf 'rewind_enable = "false"\n' >> "$PCSX_CFG"
+            fi
+            if [ -n "$swanstation_rewind_present" ]; then
+              sed -i 's/^rewind_enable = .*/rewind_enable = "false"/' "$SWANSTATION_CFG"
+            else
+              printf 'rewind_enable = "false"\n' >> "$SWANSTATION_CFG"
+            fi
             ;;
         "off")
-            log_message "RetroArch hotkey set to Start"
+            log_message "RetroArch Rewind: off"
             sed -i 's/^input_rewind = .*/input_rewind = "nul"/' "$RETROARCH_CFG"
             sed -i 's/^input_toggle_slowmotion = .*/input_toggle_slowmotion = "e"/' "$RETROARCH_CFG"
             sed -i 's/^rewind_enable = .*/rewind_enable = "false"/' "$RETROARCH_CFG"
+            sed -i '/^rewind_enable = /d' "$PCSX_CFG"
+            sed -i '/^rewind_enable = /d' "$SWANSTATION_CFG"
             ;;
     esac
 fi


### PR DESCRIPTION
Due to performance issues, rewind should not be enabled for PSX when turned on via Advanced Settings:

When RetroArch rewind is turned on, for both `PCSX-ReARMed` and `SwanStation`:
- If rewind is not present in the core configuration, an override is added that disables rewind
- If rewind is present in the core configuration, it is updated to be disabled

When RetroArch rewind is turned off, for both `PCSX-ReARMed` and `SwanStation`:
- The `rewind_enable` entry in the configuration is removed