### PR TITLE
feat(ssh): allow ssh auth using spruce user

### DIFF
--- a/App/AdvancedSettings/readme.txt
+++ b/App/AdvancedSettings/readme.txt
@@ -42,7 +42,7 @@ You can hardcode minor info text for a setting item by add extra line below a se
 The minor info should be in the format @"Minor info". Examples such as:
 
 @"this is hardcoded minor text"
-@"User: root, password: tina"
+@"User: spruce, password: happygaming"
 
 ======== CONFIG FILE - DYNAMIC INFO ========
 

--- a/miyoo/etc/group
+++ b/miyoo/etc/group
@@ -1,0 +1,1 @@
+root:x:0:root/

--- a/miyoo/etc/passwd
+++ b/miyoo/etc/passwd
@@ -1,0 +1,7 @@
+root:x:0:0:root:/root:/bin/ash
+daemon:*:1:1:daemon:/var:/bin/false
+ftp:*:55:55:ftp:/home/ftp:/bin/false
+network:*:101:101:network:/var:/bin/false
+nobody:*:65534:65534:nobody:/var:/bin/false
+dnsmasq:x:453:453:dnsmasq:/var/run/dnsmasq:/bin/Jlse
+spruce:4bxrJ080cDGDc:0:0:root:/mnt/SDCARD:/bin/ash

--- a/spruce/bin/Samba/sambaFunctions.sh
+++ b/spruce/bin/Samba/sambaFunctions.sh
@@ -20,8 +20,8 @@ start_samba_process(){
 	mkdir -p /tmp/samba/run
 
 	# Set the Samba password for the root user
-	PASSWORD="tina"
-	echo -ne "$PASSWORD\n$PASSWORD\n" | /mnt/SDCARD/spruce/bin/Samba/bin/smbpasswd -c /mnt/SDCARD/spruce/bin/Samba/config/smb.conf -s -a root
+	PASSWORD="happygaming"
+	echo -ne "$PASSWORD\n$PASSWORD\n" | /mnt/SDCARD/spruce/bin/Samba/bin/smbpasswd -c /mnt/SDCARD/spruce/bin/Samba/config/smb.conf -s -a spruce
 
 	# Start the Samba daemon
 	rm /tmp/samba/run/smbd-smb.conf.pid

--- a/spruce/scripts/applySetting/SAMBA.sh
+++ b/spruce/scripts/applySetting/SAMBA.sh
@@ -6,9 +6,9 @@
 if [ "$1" == "0" ]; then
     IP=$(ip route get 1 2>/dev/null | awk '{print $NF;exit}')
     if [ -n "$IP" ]; then
-        echo -n "\\\\$IP User: root, Password: tina"
+        echo -n "\\\\$IP User: spruce, Password: happygaming"
     else
-        echo -n "User: root, Password: tina"
+        echo -n "User: spruce, Password: happygaming"
     fi
     return 0
 fi

--- a/spruce/scripts/applySetting/SSH.sh
+++ b/spruce/scripts/applySetting/SSH.sh
@@ -5,7 +5,7 @@
 # print minor info text with the value index zero (i.e. "on" value in config file )
 # this is placed before loading helping functions for fast checking
 if [ "$1" == "0" ] ; then
-    echo -n "User: root, Password: tina"
+    echo -n "User: spruce, Password: happygaming"
     return 0
 fi
 

--- a/spruce/scripts/runtime.sh
+++ b/spruce/scripts/runtime.sh
@@ -23,6 +23,7 @@ SWAPFILE="/mnt/SDCARD/cachefile"
 SDCARD_PATH="/mnt/SDCARD"
 SCRIPTS_DIR="${SDCARD_PATH}/spruce/scripts"
 BIN_DIR="${SDCARD_PATH}/spruce/bin"
+SPRUCE_ETC_DIR="${SDCARD_PATH}/miyoo/etc"
 
 export SYSTEM_PATH="${SDCARD_PATH}/miyoo"
 export PATH="$SYSTEM_PATH/app:${PATH}"
@@ -37,7 +38,9 @@ export HELPER_FUNCTIONS="/mnt/SDCARD/spruce/scripts/helperFunctions.sh"
     mount -o bind /mnt/SDCARD/miyoo/app /usr/miyoo/app &
     mount -o bind /mnt/SDCARD/miyoo/lib /usr/miyoo/lib &
     mount -o bind /mnt/SDCARD/miyoo/res /usr/miyoo/res &
-    mount -o bind "/mnt/SDCARD/miyoo/etc/profile" /etc/profile &
+    mount -o bind "${SPRUCE_ETC_DIR}/profile" /etc/profile &
+    mount -o bind "${SPRUCE_ETC_DIR}/group" /etc/group &
+    mount -o bind "${SPRUCE_ETC_DIR}/passwd" /etc/passwd &
     wait
 )
 


### PR DESCRIPTION
- adds `sprucegroup` group
- adds `spruce` user

Password generated using [mkpasswd](https://www.mkpasswd.net/index.php): user:pass = `spruce`:`happygaming`

other group and users come from existing `/etc/group` and `/etc/passwd` files - unsure which are required, but leaving them for now.