### PR TITLE
feat(ppsspp): add Reset PPSSPP configs to Advanced Settings

### DIFF
--- a/spruce/scripts/tasks/resetPPSSPP.sh
+++ b/spruce/scripts/tasks/resetPPSSPP.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+if [ "$1" == "0" ]; then
+    echo -n "Your PPSSPP config will be reset on save and exit."
+    return 0
+fi
+
+if [ "$1" == "1" ]; then
+    echo -n "We recommend backing up first."
+    return 0
+fi
+
+. /mnt/SDCARD/spruce/scripts/helperFunctions.sh
+
+ORIGINAL_PPSSPP_FILE="/mnt/SDCARD/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
+ORIGINAL_PPSSPP_CONTROLS_FILE="/mnt/SDCARD/.config/ppsspp/PSP/SYSTEM/controls.ini"
+BACKUP_PPSSPP_FILE="/mnt/SDCARD/Emu/.emu_setup/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
+BACKUP_PPSSPP_CONTROLS_FILE="/mnt/SDCARD/Emu/.emu_setup/.config/ppsspp/PSP/SYSTEM/controls.ini"
+
+
+log_message "Resetting PPSSPP config to default."
+cp $BACKUP_PPSSPP_FILE $ORIGINAL_PPSSPP_FILE
+cp $BACKUP_PPSSPP_CONTROLS_FILE $ORIGINAL_PPSSPP_CONTROLS_FILE

--- a/spruce/settings/settings_config
+++ b/spruce/settings/settings_config
@@ -30,6 +30,7 @@ $CLEAR_WIFI=/mnt/SDCARD/spruce/scripts/tasks/clearwifi.sh$
 $RESET_EMUFRESH=/mnt/SDCARD/spruce/scripts/tasks/resetEmufresh.sh$
 $RESET_RA=/mnt/SDCARD/spruce/scripts/tasks/resetRA.sh$
 $RESET_RAHOTKEY=/mnt/SDCARD/spruce/scripts/tasks/resetRAHotkeys.sh$
+$RESET_PPSSPP=/mnt/SDCARD/spruce/scripts/tasks/resetPPSSPP.sh$
 $SIMPLE_MODE=/mnt/SDCARD/spruce/scripts/applySetting/simple_mode.sh$
 $SKIP_VERSION=/mnt/SDCARD/spruce/scripts/tasks/skipVersion.sh$
 $DELETE_MAC_FILES=/mnt/SDCARD/spruce/scripts/tasks/deleteMacFiles.sh$
@@ -147,6 +148,10 @@ $DELETE_MAC_FILES=/mnt/SDCARD/spruce/scripts/tasks/deleteMacFiles.sh$
 
 <Expert>
 "" "Reset RetroArch to spruce defaults" "|" "run|off" "echo -n off" "$RESET_RA$|" "$RESET_RA$ _INDEX_"
+@"We recommend backing up first."
+
+<Expert>
+"" "Reset PPSSPP to spruce defaults" "|" "run|off" "echo -n off" "$RESET_PPSSPP$|" "$RESET_PPSSPP$ _INDEX_"
 @"We recommend backing up first."
 
 "" "Reset Emufresh" "|" "run|off" "echo -n off" "$RESET_EMUFRESH$|" "$RESET_EMUFRESH$ _INDEX_"


### PR DESCRIPTION
This pull adds a toggle to reset your PPSSPP configuration as an expert setting in Advanced Settings.

Reset is accomplished by overwriting the following files from `Emu/.emu_setup`:
- `/mnt/SDCARD/.config/ppsspp/PSP/SYSTEM/ppsspp.ini`
- `/mnt/SDCARD/.config/ppsspp/PSP/SYSTEM/controls.ini`