### PR TITLE
chore(ci): stage releases and promote on publish

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -138,15 +138,16 @@ jobs:
           # Function to update OTA file
           update_ota_file() {
             local file="$1"
+            local nextFile="$1-next"
             local content
             content=$(cat "$file")
             
-            echo "$content" | grep -v "^RELEASE_" > "$file"
-            echo "RELEASE_VERSION=${{ steps.get_version.outputs.version }}" >> "$file"
-            echo "RELEASE_CHECKSUM=$CHECKSUM" >> "$file"
-            echo "RELEASE_SIZE_IN_MB=$SIZE_MB" >> "$file"
-            echo "RELEASE_LINK=https://github.com/spruceUI/spruceOS/releases/download/v${{ steps.get_version.outputs.version }}/spruceV${{ steps.get_version.outputs.version }}.7z" >> "$file"
-            echo "RELEASE_INFO=https://github.com/spruceUI/spruceOS/releases/tag/v${{ steps.get_version.outputs.version }}" >> "$file"
+            echo "$content" | grep -v "^RELEASE_" > "$nextFile"
+            echo "RELEASE_VERSION=${{ steps.get_version.outputs.version }}" >> "$nextFile"
+            echo "RELEASE_CHECKSUM=$CHECKSUM" >> "$nextFile"
+            echo "RELEASE_SIZE_IN_MB=$SIZE_MB" >> "$nextFile"
+            echo "RELEASE_LINK=https://github.com/spruceUI/spruceOS/releases/download/v${{ steps.get_version.outputs.version }}/spruceV${{ steps.get_version.outputs.version }}.7z" >> "$nextFile"
+            echo "RELEASE_INFO=https://github.com/spruceUI/spruceOS/releases/tag/v${{ steps.get_version.outputs.version }}" >> "$nextFile"
           }
           
           # Update main OTA file
@@ -159,14 +160,14 @@ jobs:
           cd ota_repo
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
-          git add OTA/spruce
-          git commit -m "Update release to ${{ steps.get_version.outputs.version }}"
+          git add OTA/spruce-next
+          git commit -m "Update next release to ${{ steps.get_version.outputs.version }}"
           git push https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/spruceUI/spruceui.github.io.git main
           
           # Push changes to mirror repo
           cd ../mirror_repo
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
-          git add OTA/spruce
-          git commit -m "Update release to ${{ steps.get_version.outputs.version }}"
+          git add OTA/spruce-next
+          git commit -m "Update next release to ${{ steps.get_version.outputs.version }}"
           git push https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/spruceUI/spruceSource.git main

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,44 @@
+name: Publish Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update OTA files
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          # Clone both repositories
+          git clone https://github.com/spruceUI/spruceui.github.io.git ota_repo
+          git clone https://github.com/spruceUI/spruceSource.git mirror_repo
+          
+          # Function to update OTA file
+          update_ota_file() {
+            local file="$1"
+            local nextFile="$1-next"
+
+            git rm $file
+            git mv $nextFile $file
+          }
+          
+          # Push changes to main repo
+          cd ota_repo
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+          # Update main OTA file
+          update_ota_file "ota_repo/OTA/spruce"
+          git commit -m "Update release to ${{ steps.get_version.outputs.version }}"
+          git push https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/spruceUI/spruceui.github.io.git main
+          
+          # Push changes to mirror repo
+          cd ../mirror_repo
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+          # Update mirror OTA file
+          update_ota_file "mirror_repo/OTA/spruce"
+          git commit -m "Update release to ${{ steps.get_version.outputs.version }}"
+          git push https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/spruceUI/spruceSource.git main


### PR DESCRIPTION
When we create a release (created as `draft` and `prerelease`), stage it's info in an `OTA/spruce-next` file in both the main and mirror repos. This file is then promoted to `OTA/spruce` when the release is published.