### PR TITLE
Syncthing: Fix ability to cancel during Sync, Add Timeout for Sync, and improve output to user

### DIFF
--- a/spruce/bin/Syncthing/syncthing_sync_check.sh
+++ b/spruce/bin/Syncthing/syncthing_sync_check.sh
@@ -232,7 +232,18 @@ Press START to cancel" -i "$BG_TREE"
     monitor_start_button &
     monitor_pid=$!
 
+    display -t "Syncthing Check:
+Scanning folders...
+
+Press START to cancel" -i "$BG_TREE"
+
     force_rescan
+
+    display -t "Syncthing Check:
+Searching for devices...
+
+Press START to cancel" -i "$BG_TREE"
+
     if ! smart_device_discovery; then
         # Check if it was cancelled before showing error
         if [ -f /tmp/sync_cancelled ]; then

--- a/spruce/bin/Syncthing/syncthing_sync_check.sh
+++ b/spruce/bin/Syncthing/syncthing_sync_check.sh
@@ -197,7 +197,7 @@ monitor_sync_status() {
     local folders
     folders=$(get_folders)
     local ret=$?
-    local devices=$(get_devices)
+    local devices
     local timeout=600 # 10 minutes
     local start_time=$(date +%s)
 
@@ -210,6 +210,7 @@ No folders configured" -i "$BG_TREE"
         return 1
     fi
 
+    devices=$(get_devices)
     # Then check devices
     if [ -z "$devices" ]; then
         log_message "SyncthingCheck: No devices configured. Exiting sync check."


### PR DESCRIPTION
XanXic recently fixed ability to skip Device discovery but the ability to cancel during the actual syncing process was always broken (dang Carl). I went in there and fixed that and then made some other minor improvements:

### Changes
- You can now Cancel DURING the actual Sync Process (no more getting stuck at 99% and not being able to cancel)
- I added a 10 minute TIMEOUT for the sync process (feel free to adjust this, wasn't sure if 10 minutes was too much)
- I added more display output to the user for Device Discovery and Folder Scanning which can take a while
- Only Attempt Device Discovery IF there are Folders configured

### Tested:
- Ability to Cancel when no devices are found
- Timeout during device discovery
- Bail immediately of no folders are configured
- Ability to Cancel during actual sync process (used large files for this ones)
- Timeout during sync process