### PR TITLE
Flip OTA on flip

### DIFF
--- a/Updater/updater.sh
+++ b/Updater/updater.sh
@@ -238,6 +238,10 @@ if [ "$PERFORM_DELETION" = true ]; then
     display "Cleaning up your SD card..."
     cd /mnt/SDCARD
 
+    # Back up 64-bit 7zr
+    mkdir /tmp/bin
+    cp spruce/bin64/7zr /tmp/bin
+    
     # Explicitly delete .config and .tmp_update folders
     log_update_message "Deleting .config folder"
     rm -rf .config
@@ -273,6 +277,11 @@ log_update_message "Extracting update file: $UPDATE_FILE"
 read_only_check
 
 display "Applying update. This should take around 5 minutes..."
+
+# On 64-bit systems add the backed up copy of 7zr to the path
+if [ "$ARCH" = "aarch64" ]; then
+    export PATH="/tmp/bin:$PATH"
+fi
 
 if ! 7zr x -y -scsUTF-8 "$UPDATE_FILE" >>"$LOG_LOCATION" 2>&1; then
     log_update_message "Warning: Some files may have been skipped during extraction. Check $LOG_LOCATION for details."

--- a/Updater/updaterFunctions.sh
+++ b/Updater/updaterFunctions.sh
@@ -14,10 +14,75 @@ case $INFO in
 *"TG3040"*)
 	export PLATFORM="Brick"
 	;;
+*"0xd05"*)
+    export PLATFORM="Flip"
+    ;;
 *)
     export PLATFORM="A30"
     ;;
 esac
+
+# Key exports so we can refer to buttons by more memorable names
+if [ "$PLATFORM" = "A30" ]; then
+    export B_LEFT="key 1 105"
+    export B_RIGHT="key 1 106"
+    export B_UP="key 1 103"
+    export B_DOWN="key 1 108"
+
+    export B_A="key 1 57"
+    export B_B="key 1 29"
+    export B_X="key 1 42"
+    export B_Y="key 1 56"
+
+    export B_L1="key 1 15"
+    export B_L2="key 1 18"
+    export B_R1="key 1 14"
+    export B_R2="key 1 20"
+
+    export B_START="key 1 28"
+    export B_START_2="enter_pressed" # only registers 0 on release, no 1 on press
+    export B_SELECT="key 1 97"
+    export B_SELECT_2="rctrl_pressed"
+
+    export B_VOLUP="volume up"       # only registers on press and on change, not on release. No 1 or 0.
+    export B_VOLDOWN="key 1 114"     # has actual key codes like the buttons
+    export B_VOLDOWN_2="volume down" # only registers on change. No 1 or 0.
+    export B_MENU="key 1 1"          # surprisingly functions like a regular button
+
+elif [ "$PLATFORM" = "Brick" ] || [ "$PLATFORM" = "Flip" ]; then
+    export B_LEFT="key 3 16 -1"  # negative for left
+    export B_RIGHT="key 3 16 1"  # positive for right
+    export B_UP="key 3 17 -1"    # negative for up
+    export B_DOWN="key 3 17 1"   # positive for down
+
+    export STICK_LEFT="key 3 0 -32767" # negative for left
+    export STICK_RIGHT="key 3 0 32767" # positive for right
+    export STICK_UP="key 3 1 -32767"   # negative for up
+    export STICK_DOWN="key 3 1 32767"  # positive for down
+
+    export B_A="key 1 305"
+    export B_B="key 1 304"
+    export B_X="key 1 308"
+    export B_Y="key 1 307"
+
+    export B_L1="key 1 310"
+    export B_L2="key 3 2 255" # 255 on push, nothing on release...
+    export B_R1="key 1 311"
+    export B_R2="key 3 5 255" # 255 on push, nothing on release...
+
+    export B_L3="key 1 317" # also logs left fnkey stuff
+    export B_R3="key 1 318" # also logs right fnkey stuff
+
+    export B_START="key 1 315"
+    export B_START_2="start_pressed" # only registers 0 on release, no 1.
+    export B_SELECT="key 1 314"
+    export B_SELECT_2="select_pressed" # registers both 1 and 0
+
+    export B_VOLUP="key 1 115" # has actual key codes like the buttons
+    export B_VOLDOWN="key 1 114" # has actual key codes like the buttons
+    export B_VOLDOWN_2="volume down" # only registers 0 on release, no 1.
+    export B_MENU="key 1 316"
+fi
 
 # add spruce/bin[64] folder to PATH
 case "$PLATFORM" in
@@ -37,7 +102,7 @@ acknowledge(){
         last_line=$(tail -n 1 "$messages_file")
 
         case "$last_line" in
-            *"enter_pressed"*|*"key 1 57"*|*"key 1 29"*)
+            *"enter_pressed"*|*"$B_A"*|*"$B_B"*)
                 echo "ACKNOWLEDGED $(date +%s)" >> "$messages_file"
                 break
                 ;;

--- a/spruce/scripts/helperFunctions.sh
+++ b/spruce/scripts/helperFunctions.sh
@@ -280,13 +280,13 @@ confirm() {
         last_line=$(tail -n 1 "$messages_file")
         case "$last_line" in
         # B button - cancel
-        *"key 1 29"*)
+        *"$B_B"*)
             display_kill
             echo "CONFIRM CANCELLED $(date +%s)" >>"$messages_file"
             return 1
             ;;
         # A button - confirm
-        *"key 1 57"*)
+        *"$B_A"*)
             display_kill
             echo "CONFIRM CONFIRMED $(date +%s)" >>"$messages_file"
             return 0


### PR DESCRIPTION
It's still not perfect, but this PR at least restores basic OTA update capabilities for the flip.

- Fixes the `confirm()` function in `helperFunctions.sh`
- Adds the platform-specific key mappings from `helperFunctions.sh` into `updaterFunctions.sh`
- Backs up the `7zr` binary on 64-bit architectures before cleaning files. This enables the script to still use `7zr` to extract the new archive.