### PR TITLE
Log the output of runtime.sh to help debug any startup errors

### DIFF
--- a/.tmp_update/updater
+++ b/.tmp_update/updater
@@ -30,4 +30,5 @@ if [ "$MOUNT_MODE" = "ro" ]; then #set to rw for testing
 fi
 
 cd /mnt/SDCARD/spruce/scripts
-./runtime.sh
+mkdir -p /mnt/SDCARD/spruce/logs/
+./runtime.sh > /mnt/SDCARD/spruce/logs/runtime.log


### PR DESCRIPTION
Create a new dir in /sdcard/spruce/logs
Will likely move the PortMaster logs into their as well in a future commit