### PR TITLE
Scan for segfaults when running 32-bit ports

### DIFF
--- a/Emu/PORT32/run_port.sh
+++ b/Emu/PORT32/run_port.sh
@@ -4,5 +4,9 @@ export HOME="/mnt/sdcard/spruce/flip/home"
 export LD_LIBRARY_PATH="/mnt/sdcard/spruce/flip/lib32/:/mnt/sdcard/spruce/flip/muOS/usr/lib32:$LD_LIBRARY_PATH"
 export PATH="/mnt/sdcard/spruce/flip/muOS/usr/bin:$PATH"
 
-"$1" &> /mnt/sdcard/spruce/logs/port32.log
+rm /mnt/sdcard/spruce/logs/port32.log
+/mnt/sdcard/Emu/PORT32/scan_for_segfault.sh &
+scanner_pid=$!
 
+"$1" &> /mnt/sdcard/spruce/logs/port32.log
+kill "$scanner_pid"

--- a/Emu/PORT32/scan_for_segfault.sh
+++ b/Emu/PORT32/scan_for_segfault.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Path to the log file
+LOG_FILE="/mnt/sdcard/spruce/logs/port32.log"
+
+# Check if the file exists
+while true; do
+	if [[ -f "$LOG_FILE" ]]; then
+		echo "Searching for 'SIGSEGV' in $LOG_FILE..."
+
+		# Capture the first matching line into a variable
+		sigsegv_line=$(grep "SIGSEGV" "$LOG_FILE" | head -n 1)
+
+		# Check if a match was found
+		if [[ -n "$sigsegv_line" ]]; then
+			echo "Found SIGSEGV line:"
+			echo "$sigsegv_line"
+
+			# Run the ps command, filter for 'box86', and exclude the grep process itself
+			pid=$(ps -f | grep "box86" | grep -v "grep" | awk 'NR==1 {print $2}')
+
+			# Check if a PID was found
+			if [[ -n "$pid" ]]; then
+				echo "The first PID with 'box86' (excluding grep) is: $pid. Killing..."
+				kill -9 $pid
+				exit 0
+			else
+				echo "No process with 'box86' found."
+				exit 0
+			fi
+		else
+			echo "No SIGSEGV found."
+		fi
+	else
+		echo "Log file not found: $LOG_FILE"
+		exit 1
+	fi
+	
+	sleep 5
+	
+done


### PR DESCRIPTION
box86 does not seem to close when the app it is running segfaults

This means without terminal access you would have to hard reboot the device

To get around this start a script before launching that scans the log every 5s for a segfault, and if so kills box86

