### PR TITLE
Wifi Timeout: Increase from 30 to 60 seconds

### DIFF
--- a/spruce/scripts/helperFunctions.sh
+++ b/spruce/scripts/helperFunctions.sh
@@ -175,7 +175,7 @@ check_and_connect_wifi() {
     # ########################################################################
 
     messages_file="/var/log/messages"
-    local timeout=30  # Think about making this configurable
+    local timeout=60  # Think about making this configurable
     local start_time=$(date +%s)
 
     # More thorough connection check


### PR DESCRIPTION
30 Seconds is sometimes slightly too short, ive had Wifi connect after 45 seconds due to a weak signal but it did connect! 

So I think 60 seconds is a fair and reasonable bump as it sucks to hit the timeout earlier especially knowing if I gave it a little more time it would connect