### PR TITLE
Move the flip's overlay mount for 32bit support further up

### DIFF
--- a/spruce/scripts/runtime.sh
+++ b/spruce/scripts/runtime.sh
@@ -292,6 +292,11 @@ elif [ $PLATFORM = "Brick" ] || [ $PLATFORM = "SmartPro" ]; then
 
 elif [ "$PLATFORM" = "Flip" ]; then
 
+    /mnt/sdcard/spruce/flip/recombine_large_files.sh
+    /mnt/sdcard/spruce/flip/setup_32bit_chroot.sh
+    /mnt/sdcard/spruce/flip/mount_muOS.sh
+    /mnt/sdcard/spruce/flip/setup_32bit_libs.sh
+
     echo 3 > /proc/sys/kernel/printk
     chmod a+x /usr/bin/notify
 
@@ -428,11 +433,6 @@ elif [ "$PLATFORM" = "Flip" ]; then
     else
         log_message "Auto Resume skipped (no save_active flag)"
     fi
-
-    /mnt/sdcard/spruce/flip/recombine_large_files.sh
-    /mnt/sdcard/spruce/flip/setup_32bit_chroot.sh
-    /mnt/sdcard/spruce/flip/mount_muOS.sh
-    /mnt/sdcard/spruce/flip/setup_32bit_libs.sh
 
     swapon -p 40 "${SWAPFILE}"
 


### PR DESCRIPTION
Should resolve later mounts not working due to being lost