### PR TITLE
fix devices not connecting

### DIFF
--- a/spruce/scripts/bluetooth_watchdog.sh
+++ b/spruce/scripts/bluetooth_watchdog.sh
@@ -7,8 +7,8 @@ while true; do
     inotifywait -e modify "$SYSTEM_JSON"
     BLUETOOTH="$(jq -r '.bluetooth' "$SYSTEM_JSON")"
     if [ $BLUETOOTH -eq 1 ]; then
+        /usr/bin/hciconfig hci0 up
+        /usr/bin/bluealsa -p a2dp-source &
         touch /tmp/bluetooth_ready
-    elif [ $BLUETOOTH -eq 0 ]; then
-        rm -f /tmp/bluetooth_ready
     fi
 done


### PR DESCRIPTION
We also do not need to remove /tmp/bluetooth_ready
It's deleted automatically