### PR TITLE
Update PyUI to d23d8037a91e66f6aeca380f60d43395af71d4ce

### DIFF
--- a/App/PyUI/main-ui/controller/controller.py
+++ b/App/PyUI/main-ui/controller/controller.py
@@ -56,6 +56,11 @@ class Controller:
         if timeout == -2:
             timeout = self.device.input_timeout_default
 
+        #If a long render occurred, clear the input queue
+        if time.time() - self.last_input_time > 0.2:
+            sdl2.SDL_PumpEvents()
+            self.clear_input_queue()
+
         sdl2.SDL_PumpEvents()
         start_time = time.time()
 


### PR DESCRIPTION
    If a long-render occurred, clear the input queue

    Some of the long renders need to be fixed
    Others are things like searching for roms which is expected
    to take a few seconds when theres a lot on the card