### PR TITLE
Boxart Scraper: Fix height of exit image/text on flip

### DIFF
--- a/App/BoxartScraper/scraper.sh
+++ b/App/BoxartScraper/scraper.sh
@@ -5,6 +5,18 @@
 
 IMAGE_EXIT="/mnt/SDCARD/miyoo/res/imgs/displayExit.png"
 
+case "$PLATFORM" in
+    "Brick" | "SmartPro" )
+        IMAGE_EXIT_HEIGHT=1.15
+    ;;
+    "Flip" )
+        IMAGE_EXIT_HEIGHT=1.05
+    ;;
+    "A30" )
+        IMAGE_EXIT_HEIGHT=1.15
+    ;;
+esac
+
 # ==========================================================
 # Box Art Scraper Script
 # ==========================================================
@@ -145,7 +157,7 @@ messages_file="/var/log/messages"
 
 roms_dir="/mnt/SDCARD/Roms"
 
-display --icon "/mnt/SDCARD/spruce/imgs/image.png" -t "Scraping box art..." --add-image "$IMAGE_EXIT" 1.15 195 middle
+display --icon "/mnt/SDCARD/spruce/imgs/image.png" -t "Scraping box art..." --add-image "$IMAGE_EXIT" "$IMAGE_EXIT_HEIGHT" 195 middle
 
 # Check if WiFi is enabled in system config
 wifi_enabled=$(awk '/wifi/ { gsub(/[,]/,"",$2); print $2}' "$SYSTEM_JSON")
@@ -194,7 +206,7 @@ for sys_dir in "$roms_dir"/*/; do
     icon_path="$(jq ".iconsel" "/mnt/SDCARD/Emu/$sys_name/config.json")"
 
     display --icon "\"$icon_path\"" -t "System: $sys_label 
-    Scraping boxart for $amount_games games..." --add-image "$IMAGE_EXIT" 1.15 195 middle
+    Scraping boxart for $amount_games games..." --add-image "$IMAGE_EXIT" "$IMAGE_EXIT_HEIGHT" 195 middle
     if [ -z "$extensions" ]; then
         log_message "BoxartScraper: No supported extensions found for directory $sys_name, skipping"
         continue

--- a/App/BoxartScraper/scraper.sh
+++ b/App/BoxartScraper/scraper.sh
@@ -5,18 +5,6 @@
 
 IMAGE_EXIT="/mnt/SDCARD/miyoo/res/imgs/displayExit.png"
 
-case "$PLATFORM" in
-    "Brick" | "SmartPro" )
-        IMAGE_EXIT_HEIGHT=1.15
-    ;;
-    "Flip" )
-        IMAGE_EXIT_HEIGHT=1.05
-    ;;
-    "A30" )
-        IMAGE_EXIT_HEIGHT=1.15
-    ;;
-esac
-
 # ==========================================================
 # Box Art Scraper Script
 # ==========================================================
@@ -157,7 +145,7 @@ messages_file="/var/log/messages"
 
 roms_dir="/mnt/SDCARD/Roms"
 
-display --icon "/mnt/SDCARD/spruce/imgs/image.png" -t "Scraping box art..." --add-image "$IMAGE_EXIT" "$IMAGE_EXIT_HEIGHT" 195 middle
+display --icon "/mnt/SDCARD/spruce/imgs/image.png" -t "Scraping box art..." --add-image "$IMAGE_EXIT" 1.05 195 middle
 
 # Check if WiFi is enabled in system config
 wifi_enabled=$(awk '/wifi/ { gsub(/[,]/,"",$2); print $2}' "$SYSTEM_JSON")
@@ -206,7 +194,7 @@ for sys_dir in "$roms_dir"/*/; do
     icon_path="$(jq ".iconsel" "/mnt/SDCARD/Emu/$sys_name/config.json")"
 
     display --icon "\"$icon_path\"" -t "System: $sys_label 
-    Scraping boxart for $amount_games games..." --add-image "$IMAGE_EXIT" "$IMAGE_EXIT_HEIGHT" 195 middle
+    Scraping boxart for $amount_games games..." --add-image "$IMAGE_EXIT" 1.05 195 middle
     if [ -z "$extensions" ]; then
         log_message "BoxartScraper: No supported extensions found for directory $sys_name, skipping"
         continue


### PR DESCRIPTION
Fixed the Exit Image/Text being cut off on the flip

i don't own any other devices to check if their correct, I just set all planned supported devices to match the old setting