### PR TITLE
Add GS support for when running with PyUI

### DIFF
--- a/spruce/scripts/homebutton_watchdog.sh
+++ b/spruce/scripts/homebutton_watchdog.sh
@@ -277,6 +277,13 @@ long_press_handler() {
         case $HOLD_HOME in
         "Game Switcher")
             prepare_game_switcher
+
+            if ps -f | grep -q "[/]mnt/SDCARD/spruce/flip/bin/python3 /mnt/SDCARD/App/PyUI/main-ui/mainui.py"; then
+                rm /tmp/cmd_to_run.sh
+				touch /mnt/SDCARD/spruce/flags/gs.lock
+                killall -9 python3
+            fi
+
             ;;
         "In-game menu")
             if pgrep "ra32.miyoo" >/dev/null; then


### PR DESCRIPTION
PyUI doesn't restore back to the exact spot left when using spruce theme, but does for Daijisho themes. Need to fix that in PyUI though (probably as a config option)