### PR TITLE
Make WiFi checks based on platform, not existance of a file

### DIFF
--- a/spruce/scripts/helperFunctions.sh
+++ b/spruce/scripts/helperFunctions.sh
@@ -113,7 +113,7 @@ check_and_connect_wifi() {
         log_message "Attempting to connect to WiFi"
 
         # Bring the existing interface down cleanly if its running
-        if [ ! -f /mnt/sdcard/Saves/.disablesprucewifi ]; then
+        if [ "$PLATFORM" != "Flip" ]; then
             ifconfig wlan0 down
             killall wpa_supplicant
             killall udhcpc
@@ -123,7 +123,7 @@ check_and_connect_wifi() {
             wpa_supplicant -B -i wlan0 -c $WPA_SUPPLICANT_FILE
             udhcpc -i wlan0 &
         else
-            log_message "Letting stock OS restart wifi due to existance of /mnt/sdcard/Saves/.disablesprucewifi"
+            log_message "Letting stock OS restart wifi for the FLIP"
         fi
 		
         display --icon "/mnt/SDCARD/spruce/imgs/signal.png" -t "Waiting to connect....

--- a/spruce/scripts/runtime.sh
+++ b/spruce/scripts/runtime.sh
@@ -20,14 +20,6 @@ case "$PLATFORM" in
     "Flip") SPRUCE_ETC_DIR="/mnt/SDCARD/miyoo355/etc" ;;
 esac
 
-if [ -f "$PYUI_FLAG" ]; then
-	touch /mnt/sdcard/Saves/.disablesprucewifi
-    log_message "runtime.sh: Disabling wifi services as pyui flag is true"
-else
-	rm /mnt/sdcard/Saves/.disablesprucewifi
-fi
-
-
 # Resetting log file location
 log_file="/mnt/SDCARD/Saves/spruce/spruce.log"
 

--- a/spruce/scripts/tasks/clearwifi.sh
+++ b/spruce/scripts/tasks/clearwifi.sh
@@ -2,8 +2,8 @@
 
 . /mnt/SDCARD/spruce/scripts/helperFunctions.sh
 
-if [ -f /mnt/sdcard/Saves/.disablesprucewifi ]; then
-    log_message "clearwifi disabled due to existence of /mnt/sdcard/Saves/.disablesprucewifi"
+if [ "$PLATFORM" != "Flip" ]; then
+    log_message "clearwifi disabled due to running on the Flip"
     exit 0
 fi
 

--- a/spruce/scripts/wifi_watchdog.sh
+++ b/spruce/scripts/wifi_watchdog.sh
@@ -2,8 +2,8 @@
 
 . /mnt/SDCARD/spruce/scripts/helperFunctions.sh
 
-if [ -f /mnt/sdcard/Saves/.disablesprucewifi ]; then
-    log_message "wifi_watchdog disabled due to existence of /mnt/sdcard/Saves/.disablesprucewifi"
+if [ "$PLATFORM" != "Flip" ]; then
+    log_message "wifi_watchdog disabled due to running on the Flip"
     exit 0
 fi
 

--- a/spruce/scripts/wpa_watchdog.sh
+++ b/spruce/scripts/wpa_watchdog.sh
@@ -4,8 +4,8 @@
 
 . /mnt/SDCARD/spruce/scripts/helperFunctions.sh
 
-if [ -f /mnt/sdcard/Saves/.disablesprucewifi ]; then
-    log_message "wpa_watchdog disabled due to existence of /mnt/sdcard/Saves/.disablesprucewifi"
+if [ "$PLATFORM" != "Flip" ]; then
+    log_message "wpa_watchdog disabled due to running on the flip"
     exit 0
 fi
 


### PR DESCRIPTION
Should clear up any reboot needed, and let us decide which platforms to have it enabled on (since existence of a file is true regardless of if on the a30 or flip)