### PR TITLE
Fix checking for roms in all viable folders for a given game system

### DIFF
--- a/App/PyUI/main-ui/games/utils/rom_utils.py
+++ b/App/PyUI/main-ui/games/utils/rom_utils.py
@@ -61,12 +61,11 @@ class RomUtils:
                     else:
                         if Path(entry.name).suffix.lower() in valid_suffix_set:
                             return True
-
-                return False  # No valid files found
+                        
             except Exception as e:
                 PyUiLogger.get_logger().error(f"Error scanning directory '{dir_to_search}': {e}")
 
-        return False
+        return False # No valid files found
     
 
     def get_roms(self, game_system: GameSystem, directory=None):


### PR DESCRIPTION
Fixes #547 

Game systems won't show up if there's an empty game system folder on the main SD card and that's the case for every system after spruceOS install. This fix restores proper behavior and now the system will properly show up in UI when roms are detected on the Second SD card or any other viable roms folder.