### PR TITLE
Use better check for running emulator

### DIFF
--- a/spruce/scripts/homebutton_watchdog.sh
+++ b/spruce/scripts/homebutton_watchdog.sh
@@ -19,6 +19,9 @@ LIST_FILE="$SETTINGS_PATH/gs_list"
 TEMP_FILE="$TEMP_PATH/gs_list_temp"
 RETROARCH_CFG="/mnt/SDCARD/RetroArch/retroarch.cfg"
 
+# Pattern for checking emulator usage
+EMU_PATTERN="/(mnt/SDCARD|media/sdcard[0,1])/Emu"
+
 kill_port(){
 	scan=true
     while $scan; do
@@ -115,7 +118,7 @@ prepare_game_switcher() {
 
         # check command is emulator
         # exit if not emulator is in command
-        if echo "$CMD" | grep -q -v "$SD_FOLDER_PATH/Emu"; then
+        if echo "$CMD" | grep -q -v -E "$EMU_PATTERN"; then
             return 0
         fi
 


### PR DESCRIPTION
PyUI will use absolute paths to support loading games from the second SD card but this can change the emulator path passed to the launch script. Use a nice pattern that allows the `Emu` folder to reside in any combination of `/mnt` or /media` + `sdcard` with, or without number.

This means GS will properly work for Emulators in `/mnt/SDCARD/Emu` and `/media/sdcard0/Emu`