### PR TITLE
Fix emulator pattern matching in watchdog script

### DIFF
--- a/spruce/scripts/homebutton_watchdog.sh
+++ b/spruce/scripts/homebutton_watchdog.sh
@@ -20,7 +20,7 @@ TEMP_FILE="$TEMP_PATH/gs_list_temp"
 RETROARCH_CFG="/mnt/SDCARD/RetroArch/retroarch.cfg"
 
 # Pattern for checking emulator usage
-EMU_PATTERN="/(mnt/SDCARD|media/sdcard[0,1])/Emu"
+EMU_PATTERN="/(mnt|media)/sdcard[0,1]?)/Emu"
 
 kill_port(){
 	scan=true
@@ -118,7 +118,7 @@ prepare_game_switcher() {
 
         # check command is emulator
         # exit if not emulator is in command
-        if echo "$CMD" | grep -q -v -E "$EMU_PATTERN"; then
+        if echo "$CMD" | grep -q -v -E -i "$EMU_PATTERN"; then
             return 0
         fi
 


### PR DESCRIPTION
We don't care about capitalization here and lowercase, bare `/mnt/sdcard/` is a viable pattern