### PR TITLE
Localize getting charging/battery status to the individual device

### DIFF
--- a/spruce/scripts/helperFunctions.sh
+++ b/spruce/scripts/helperFunctions.sh
@@ -281,15 +281,6 @@ flag_remove() {
     rm -f "$FLAGS_DIR/${flag_name}.lock"
 }
 
-# 'Discharging', 'Charging', or 'Full' are possible values. Mind the capitalization.
-get_charging_status() {
-	cat "$BATTERY/status"
-}
-
-get_battery_percent() {
-	cat "$BATTERY/capacity"
-}
-
 # Call this to get the last button pressed
 # Returns the name of the button pressed, or "" if no matching button was pressed
 # Returned strings are simplified, so "B_L1" would return "L1"

--- a/spruce/scripts/low_power_warning.sh
+++ b/spruce/scripts/low_power_warning.sh
@@ -46,7 +46,7 @@ log_battery() {
     CURRENT_TIME=$(date "+%Y-%m-%d %H:%M:%S")
 
     # Check charging status
-    CHARGING=$(get_charging_status)
+    CHARGING=$(device_get_charging_status)
 
     # Append new log entry with appropriate status
     if [ "$CHARGING" = "Charging" ]; then
@@ -81,7 +81,7 @@ fi
 LAST_LOG=$(date +%s)
 
 while true; do
-    CAPACITY=$(get_battery_percent)
+    CAPACITY=$(device_get_battery_percent)
     PERCENT="$(get_config_value '.menuOptions."Battery Settings".lowPowerWarningPercent.selected' "4")"
     LED_MODE="$(get_config_value '.menuOptions."Battery Settings".ledMode.selected' "Always off")"
     
@@ -123,7 +123,7 @@ while true; do
                 morse_code_sos "false" "." "." "." "-" "-" "-" "." "." "."
             fi
 
-            CAPACITY=$(get_battery_percent)
+            CAPACITY=$(device_get_battery_percent)
             PERCENT="$(get_config_value '.menuOptions."Battery Settings".lowPowerWarningPercent.selected' "4")"
 
             hard_shutdown $CAPACITY

--- a/spruce/scripts/platform/device.sh
+++ b/spruce/scripts/platform/device.sh
@@ -269,3 +269,12 @@ brightness_down() {
 brightness_up() {
     log_message "Missing brightness_up function"
 }
+
+# 'Discharging', 'Charging', or 'Full' are possible values. Mind the capitalization.
+device_get_charging_status() {
+    log_message "Missing device_get_charging_status function"
+}
+
+device_get_battery_percent() {
+    log_message "Missing device_get_battery_percent function"
+}

--- a/spruce/scripts/platform/device_functions/A30.sh
+++ b/spruce/scripts/platform/device_functions/A30.sh
@@ -75,6 +75,9 @@ vibrate() {
     else
         log_message "this is where I'd put my vibration... IF I HAD ONE"
     fi
+
+    echo 0 >/sys/devices/virtual/timed_output/vibrator/enable
+
 }
 
 
@@ -367,4 +370,14 @@ volume_up() {
 
 get_volume_level() {
     amixer_get_volume_level
+}
+
+
+# 'Discharging', 'Charging', or 'Full' are possible values. Mind the capitalization.
+device_get_charging_status() {
+	cat "$BATTERY/status"
+}
+
+device_get_battery_percent() {
+	cat "$BATTERY/capacity"
 }

--- a/spruce/scripts/platform/device_functions/Flip.sh
+++ b/spruce/scripts/platform/device_functions/Flip.sh
@@ -426,3 +426,13 @@ volume_up() {
 get_volume_level() {
     amixer_get_volume_level
 }
+
+
+# 'Discharging', 'Charging', or 'Full' are possible values. Mind the capitalization.
+device_get_charging_status() {
+	cat "$BATTERY/status"
+}
+
+device_get_battery_percent() {
+	cat "$BATTERY/capacity"
+}

--- a/spruce/scripts/platform/device_functions/SmartProS.sh
+++ b/spruce/scripts/platform/device_functions/SmartProS.sh
@@ -391,3 +391,13 @@ run_mixer_watchdog() {
 new_execution_loop() {
     log_message "new_execution_loop Uneeded on this device" -v
 }
+
+
+# 'Discharging', 'Charging', or 'Full' are possible values. Mind the capitalization.
+device_get_charging_status() {
+	cat "$BATTERY/status"
+}
+
+device_get_battery_percent() {
+	cat "$BATTERY/capacity"
+}

--- a/spruce/scripts/platform/device_functions/trimui_a133p.sh
+++ b/spruce/scripts/platform/device_functions/trimui_a133p.sh
@@ -222,3 +222,13 @@ set_playback_path() {
 run_mixer_watchdog() {
     log_message "run_mixer_watchdog on this device" -v
 }
+
+
+# 'Discharging', 'Charging', or 'Full' are possible values. Mind the capitalization.
+device_get_charging_status() {
+	cat "$BATTERY/status"
+}
+
+device_get_battery_percent() {
+	cat "$BATTERY/capacity"
+}


### PR DESCRIPTION
Update miyoomini to support low_power_warning.

NOTE: Display will not function on the miyoo mini, though with the current implementation this is also broken on the big flip due to KMS only allowing one thing to draw to the screen at a time without massive flickering