### PR TITLE
Re-enable calling trimui osdd if fw is not 1.1.0 which seems broken

### DIFF
--- a/spruce/scripts/platform/device_functions/SmartPro.sh
+++ b/spruce/scripts/platform/device_functions/SmartPro.sh
@@ -45,6 +45,15 @@ get_spruce_ra_cfg_location() {
     echo "/mnt/SDCARD/RetroArch/platform/retroarch-SmartPro.cfg"
 }
 
+get_fw_version() {
+    tr -d ' \t\n' < /etc/version 2>/dev/null
+}
+
 device_init() {
     device_init_a133p
+
+    version="$(get_fw_version)"
+    if [ "$version" != "1.1.0" ]; then
+        run_trimui_osdd
+    fi
 }


### PR DESCRIPTION
Haven't tested but should align with what Ry is using before i disabled it