### PR TITLE
fix pixelreader activity for first launch

### DIFF
--- a/App/PixelReader/.pixel_reader_store/activity
+++ b/App/PixelReader/.pixel_reader_store/activity
@@ -1,1 +1,1 @@
-browser_path=/mnt/sdcard/Roms/EBOOKS/Doyle
+browser_path=/mnt/sdcard/Roms/EBOOKS/


### PR DESCRIPTION
browser_path specified a non-existent path causing default directory on launch to be root fs folder