### PR TITLE
Option for new themes to autoalign icons and their bgs

### DIFF
--- a/App/PyUI/main-ui/menus/settings/theme/theme_settings_grid_view.py
+++ b/App/PyUI/main-ui/menus/settings/theme/theme_settings_grid_view.py
@@ -54,7 +54,10 @@ class ThemeSettingsGridView(ThemeSettingsMenuCommon):
                 max=10000
             )
         )
-
-        
+        option_list.append(
+            self.build_enabled_disabled_entry("Set Grid BG Offset To Image Offset",
+                                                Theme.grid_bg_offset_to_image_offset,
+                                                Theme.set_grid_bg_offset_to_image_offset)
+        )        
 
         return option_list

--- a/App/PyUI/main-ui/themes/theme.py
+++ b/App/PyUI/main-ui/themes/theme.py
@@ -1496,6 +1496,15 @@ class Theme():
         cls.save_changes()
 
     @classmethod
+    def grid_bg_offset_to_image_offset(cls):
+        return cls._data.get("gridBgOffsetToImageOffset", False)
+
+    @classmethod
+    def set_grid_bg_offset_to_image_offset(cls, value):
+        cls._data["gridBgOffsetToImageOffset"] = value
+        cls.save_changes()
+
+    @classmethod
     def single_row_grid_text_y_offset(cls):
         return cls._data.get("singleRowGridTextYOffset", 0)
 

--- a/App/PyUI/main-ui/views/grid_view.py
+++ b/App/PyUI/main-ui/views/grid_view.py
@@ -63,7 +63,7 @@ class GridView(View):
         self.x_pad = 10
         self.usable_width = Device.screen_width() - (2 * self.x_pad)
         self.icon_width = self.usable_width / self.cols  # Initial icon width
-
+        self.set_bg_offset_to_image_offset = Theme.grid_bg_offset_to_image_offset()
 
     def set_options(self, options):
         self.options = options
@@ -185,7 +185,10 @@ class GridView(View):
             bg_width += Theme.get_grid_multi_row_sel_bg_resize_pad_width()
             bg_height += Theme.get_grid_multi_row_sel_bg_resize_pad_height()
             if(YRenderOption.CENTER == render_mode.y_mode):
-                bg_offset = 0
+                if(self.set_bg_offset_to_image_offset):
+                    bg_offset = img_offset
+                else:
+                    bg_offset = 0
             elif(YRenderOption.BOTTOM == render_mode.y_mode):
                 bg_offset = Theme.get_grid_multi_row_sel_bg_resize_pad_height() //2    
 
@@ -200,7 +203,7 @@ class GridView(View):
         elif(self.unselected_bg is not None):
             Display.render_image(self.unselected_bg,
                          x_offset,
-                         cell_y,
+                         cell_y + bg_offset // offset_divisor,
                          render_mode,
                          target_width=int(bg_width*1.05),
                          target_height=int(bg_height*1.05))


### PR DESCRIPTION
Default miyoo seems to offset them which is annoying if just making a new theme So make the offsetting optional