### PR TITLE
Enhance nightly workflow with ZIP creation and cleanup

### DIFF
--- a/.github/workflows/create-nightly.yml
+++ b/.github/workflows/create-nightly.yml
@@ -1,11 +1,7 @@
 name: Create Nightly
 
 on:
-#  schedule:
-#    - cron: '10 10 * * *'
   workflow_dispatch:
-#  push:
-#    branches: [ Development ]
 
 jobs:
   create-7z:
@@ -18,10 +14,10 @@ jobs:
           ref: Development
           fetch-depth: 0
 
-      - name: Install 7zip
+      - name: Install 7zip and zip
         run: |
           sudo apt-get update
-          sudo apt-get install -y p7zip-full
+          sudo apt-get install -y p7zip-full zip
 
       - name: Get version and date
         id: get_version
@@ -118,6 +114,25 @@ jobs:
           # Add the commits file separately to place it at the root
           7z u "spruceV${{ steps.get_version.outputs.version }}.7z" commits_nightly.txt
 
+      - name: Create ZIP archive
+        run: |
+          echo "Creating regular ZIP archive..."
+          ZIP_NAME="spruceV${{ steps.get_version.outputs.version }}.zip"
+          zip -r9 "$ZIP_NAME" * .tmp_update \
+            -x ".git/*" \
+            -x ".github/*" \
+            -x ".gitignore" \
+            -x ".gitattributes" \
+            -x "create_spruce_release.bat" \
+            -x "create_spruce_release.sh" \
+            -x "commits_nightly.txt"
+          # Add the commits file to the root
+          zip "$ZIP_NAME" commits_nightly.txt
+          # Optional integrity check
+          echo "Testing ZIP integrity..."
+          zip -T "$ZIP_NAME"
+          echo "ZIP archive $ZIP_NAME created successfully"
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         if: success() && steps.check_commits.outcome == 'success'
@@ -190,13 +205,7 @@ jobs:
           COUNT=0
           for RELEASE_ID in $RELEASES; do
             COUNT=$((COUNT + 1))
-            if [ $COUNT -gt 3 ]; then
+            if [ $COUNT -gt 14 ]; then
               gh api repos/spruceUI/spruceOSNightlies/releases/$RELEASE_ID -X DELETE
             fi
-
           done
-
-
-
-
-


### PR DESCRIPTION
Updated the nightly workflow to include ZIP archive creation and install zip alongside 7zip. Adjusted the logic for deleting old releases to keep only the latest 14.