### PR TITLE
Fix 7z nightly to be miyoo mini compatible

### DIFF
--- a/.github/workflows/create-nightly.yml
+++ b/.github/workflows/create-nightly.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Create 7z archive
         run: |
-          7z a -t7z -mx=9 -mf=off "spruceV${{ steps.get_version.outputs.version }}.7z" * .tmp_update \
+          7z a -t7z -m0=lzma2:d=16m -mx=7 -ms=off "spruceV${{ steps.get_version.outputs.version }}.7z" * .tmp_update \
             -xr!.git \
             -xr!.github \
             -x!.gitignore \


### PR DESCRIPTION
Don't create a solid archive

File size goes from 1.33gb to 1.43gb but is now miyoo mini compatible as well