### PR TITLE
Reduce fan profiles to only ones that are practically different

### DIFF
--- a/Saves/spruce/spruce-config.json
+++ b/Saves/spruce/spruce-config.json
@@ -210,12 +210,8 @@
                 "description": "Customize fan profiles",
                 "options": [
                     "Stock",
-                    "Adaptive Performance",
-                    "Adaptive Balanced",
-                    "Adaptive Quiet",
-                    "Quiet",
-                    "Balanced",
-                    "Performance"
+                    "Adaptive",
+                    "Cool"
                 ],
                 "selected": "Stock"
             }


### PR DESCRIPTION
Stock is stock
Cool keeps the fan on at relatiely high levels before any throttling will even occur Adaptive tries to find the lowest fan speed to remain below throttling

Updated the comments to indicate what each trip point does from emperical testing