### PR TITLE
Use miyoogamelist.xml for subfolders as well

### DIFF
--- a/App/PyUI/main-ui/menus/games/utils/rom_select_options_builder.py
+++ b/App/PyUI/main-ui/menus/games/utils/rom_select_options_builder.py
@@ -253,19 +253,24 @@ class RomSelectOptionsBuilder:
                 )
 
         for rom_file_path in valid_folders:
-            rom_info = RomInfo(game_system,rom_file_path)
             rom_file_name = os.path.basename(rom_file_path)
+            game_entry = miyoo_game_list.get_by_file_path(rom_file_path)
             if(filter(rom_file_name, rom_file_path)):
+                if(game_entry is not None):
+                    display_name = game_entry.name
+                else:
+                    display_name = rom_file_name
+
+                rom_info = RomInfo(game_system, rom_file_path, display_name)
 
                 folder_rom_list.append(
                     GridOrListEntry(
-                        primary_text=rom_file_name,
+                        primary_text=display_name,
                         description=game_system.folder_name, 
                         value=rom_info,
-                        image_path_searcher=lambda rom_info: self.get_image_path(rom_info),
-                        image_path_selected_searcher=lambda rom_info: self.get_image_path(
-                            rom_info, prefer_savestate_screenshot=prefer_savestate_screenshot),
-                        icon_searcher=lambda rom_info: self._get_favorite_icon(rom_info)
+                        image_path_searcher=lambda rom_info=rom_info, game_entry=game_entry: self.get_image_path(rom_info, game_entry, prefer_savestate_screenshot=prefer_savestate_screenshot),
+                        image_path_selected_searcher=lambda rom_info=rom_info, game_entry=game_entry: self.get_image_path(rom_info, game_entry, prefer_savestate_screenshot=prefer_savestate_screenshot),
+                        icon_searcher=lambda rom_info=rom_info: self._get_favorite_icon(rom_info)
                     )
                 )
 


### PR DESCRIPTION
Trying to get miyoogamelist.xml to work with 
<path/> <name/> <image/>
for folders.
You should use <game/> instead of <folder/>.
The effects on the function of other spruceOS should be tested.