### PR TITLE
Fix transparency loss by forcing RGBA pixel format

### DIFF
--- a/App/PyUI/main-ui/utils/ffmpeg_image_utils.py
+++ b/App/PyUI/main-ui/utils/ffmpeg_image_utils.py
@@ -68,6 +68,7 @@ class FfmpegImageUtils(ImageUtils):
                     "-y",
                     "-i", input_path,
                     "-vf", scale_filter,
+                    "-pix_fmt", "rgba",
                     "-frames:v", "1",
                     "-update", "1",
                     temp_path


### PR DESCRIPTION
[Problem]
When converting 8-bit Colormap (Indexed) PNG files, ffmpeg fails to recognize the transparency channel, causing the background to render as solid black.

[Cause]
The -pix_fmt rgba option was missing in the shrink_image_if_needed routine. This caused ffmpeg to generate intermediate files in a standard RGB format that does not support transparency.

[Solution]
Force the -pix_fmt rgba option in all ffmpeg calls, especially during the resizing stage. This ensures any input PNG is immediately expanded to 32-bit RGBA in memory, preserving transparency throughout the process.