### PR TITLE
Avoid accidentally setting smart mode when switching between games quickly

### DIFF
--- a/spruce/scripts/platform/device_functions/Flip.sh
+++ b/spruce/scripts/platform/device_functions/Flip.sh
@@ -252,7 +252,9 @@ prepare_for_pyui_launch(){
     (
         # SDL2 takes forever, let it initialize before going to powersave
         sleep 5
-        set_smart
+        if flag_check "in_menu"; then
+            set_smart
+        fi
         unlock_governor 2>/dev/null
     ) &
 }


### PR DESCRIPTION
When switching between games quickly, like with the GameSwitcher or from the menu if fast enough, the Smart performance profile will be applied. This happens because in prepare_for_pyui_launch() in Flip.sh the Performance mode is set temporarily to speed up the process, but when switching back to Smart it doesn't check if a game was launched since and forces it anyways.

Log of the bug (I added a few messages to show what's happening):
```
2026-02-07 01:22:46 - Starting PyUI on Flip
2026-02-07 01:22:50 - Missing post_pyui_exit function
2026-02-07 01:22:50 - set_performance called
2026-02-07 01:22:50 - Setting cores online: 0123
2026-02-07 01:22:50 - CPU Mode now locked to PERFORMANCE: 0123 @ 1800000
2026-02-07 01:22:50 - -----Launching Emulator-----
2026-02-07 01:22:50 - trying: /mnt/SDCARD/Emu/PS/../../spruce/scripts/emu/standard_launch.sh /media/sdcard1/Roms/PS/Crash Bandicoot - Warped (USA).cue
2026-02-07 01:22:51 - EMU_NAME is PS, EMU_DIR is /mnt/SDCARD/Emu/PS, GAME is Crash Bandicoot - Warped (USA).cue, MODE is Overclock
2026-02-07 01:22:51 - Setting CPU mode to Overclock
2026-02-07 01:22:51 - Applying overclock mode
2026-02-07 01:22:51 - set_overclock called
2026-02-07 01:22:51 - Setting cores online: 01234567
2026-02-07 01:22:51 - Setting cores online: 0123
2026-02-07 01:22:51 - CPU Mode now locked to OVERCLOCK: 0123 @ 1992000
2026-02-07 01:22:51 - Setting Smart mode from Flip.sh prepare_for_pyui
2026-02-07 01:22:51 - export LD_LIBRARY_PATH="/mnt/SDCARD/spruce/flip/lib:/usr/miyoo/lib:/usr/lib:/lib"
2026-02-07 01:22:51 - export PATH="/mnt/SDCARD/spruce/bin64:/usr/miyoo/bin:/usr/bin:/usr/sbin:/bin:/sbin"
2026-02-07 01:22:51 - Running CMD: HOME="/mnt/SDCARD/RetroArch/" "/mnt/SDCARD/RetroArch/retroarch.Flip" -v --log-file /mnt/SDCARD/Saves/spruce/retroarch.log -L "/mnt/SDCARD/RetroArch/.retroarch/cores64/pcsx_rearmed_libretro.so" "/media/sdcard1/Roms/PS/Crash Bandicoot - Warped (USA).cue"
2026-02-07 01:22:51 - Setting cores online: 01
2026-02-07 01:22:51 - CPU Mode now locked to SMART: core(s) 01 @ 408000 to 1800000
```

With the fix:
```
2026-02-07 01:43:25 - Setting cores online: 01234567
2026-02-07 01:43:25 - Setting cores online: 0123
2026-02-07 01:43:25 - CPU Mode now locked to OVERCLOCK: 0123 @ 1992000
2026-02-07 01:43:25 - export LD_LIBRARY_PATH="/mnt/SDCARD/spruce/flip/lib:/usr/miyoo/lib:/usr/lib:/lib"
2026-02-07 01:43:25 - export PATH="/mnt/SDCARD/spruce/bin64:/usr/miyoo/bin:/usr/bin:/usr/sbin:/bin:/sbin"
2026-02-07 01:43:25 - Running CMD: HOME="/mnt/SDCARD/RetroArch/" "/mnt/SDCARD/RetroArch/retroarch.Flip" -v --log-file /mnt/SDCARD/Saves/spruce/retroarch.log -L "/mnt/SDCARD/RetroArch/.retroarch/cores64/pcsx_rearmed_libretro.so" "/media/sdcard1/Roms/PS/Crash Bandicoot - Warped (USA).cue"
2026-02-07 01:43:26 - Setting Smart mode from Flip.sh prepare_for_pyui
2026-02-07 01:43:26 - Tried to set Smart mode, but was not in-menu
2026-02-07 01:43:30 - Menu button pressed at 1770428610
2026-02-07 01:43:31 - homebutton_watchdog.sh: Performing hold-home action: Game Switcher
2026-02-07 01:43:31 - homebutton_watchdog.sh: 'SCREENSHOT_NAME': /mnt/SDCARD/Saves/states/.gameswitcher/Crash Bandicoot - Warped (USA).state.auto.png
2026-02-07 01:43:31 - homebutton_watchdog.sh: Killing miscelaneous emus!
2026-02-07 01:43:31 - Menu button released at 1770428611
2026-02-07 01:43:32 - -----Closing Emulator-----
```

