### PR TITLE
Fix asound rc file for at least the miyoo flip when bluetooth is disabled

### DIFF
--- a/spruce/scripts/asound-setup.sh
+++ b/spruce/scripts/asound-setup.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. /mnt/SDCARD/spruce/scripts/helperFunctions.sh
+
 # Modified From CarlOS launch.sh script
 
 # Allow HOME override via first argument
@@ -58,4 +60,5 @@ ctl.!default {
 EOF
 else
     [ -f "$ASOUND_CONF" ] && rm "$ASOUND_CONF"
+    device_write_default_asound_rc
 fi

--- a/spruce/scripts/platform/device.sh
+++ b/spruce/scripts/platform/device.sh
@@ -315,3 +315,9 @@ device_wifi_power_on() {
 device_wifi_power_off() { 
     log_message "Missing device_wifi_power_off function" -v
 }
+
+device_write_default_asound_rc() {
+    # Do these need to be unique per device? Don't have a way 
+    # to test currently
+    log_message "Missing device_write_default_asound_rc function" -v
+}

--- a/spruce/scripts/platform/device_functions/Flip.sh
+++ b/spruce/scripts/platform/device_functions/Flip.sh
@@ -515,3 +515,17 @@ device_wifi_power_on() {
 device_wifi_power_off() { 
     echo 0 > /sys/class/rkwifi/wifi_power
 }
+
+device_write_default_asound_rc() {
+    cat > "$ASOUND_CONF" <<EOF
+pcm.!default {
+    type plug
+    slave.pcm "dmix"
+}
+
+ctl.!default {
+    type hw
+    card 0
+}
+EOF
+}


### PR DESCRIPTION
Need to test / figure out for the other devices so ports requiring them work again