### PR TITLE
pixel2: hide option to check for updates at boot

### DIFF
--- a/Saves/spruce/spruce-config.json
+++ b/Saves/spruce/spruce-config.json
@@ -138,6 +138,15 @@
         "System Settings": {
 
             "checkForUpdates": {
+                "devices":["MIYOO_FLIP",
+                           "MIYOO_MINI",
+                           "MIYOO_MINI_V4",
+                           "MIYOO_MINI_PLUS",
+                           "MIYOO_MINI_FLIP",
+                           "TRIMUI_BRICK",
+                           "TRIMUI_SMART_PRO",
+                           "TRIMUI_SMART_PRO_S",
+                           "MIYOO_A30"],
                 "display": "Check for spruce updates on startup",
                 "description": "if connected to Wi-Fi",
                 "options": [


### PR DESCRIPTION
Device can't startup with wifi on anyway.