### PR TITLE
Add ScummVM scanner

### DIFF
--- a/Emu/SCUMMVM/config.json
+++ b/Emu/SCUMMVM/config.json
@@ -14,6 +14,15 @@
         "TRIMUI_SMART_PRO",
         "TRIMUI_SMART_PRO_S"
       ]
+    },
+    {
+      "name": "Scan ScummVM Games",
+      "launch": "/mnt/SDCARD/Emu/SCUMMVM/scan_scummvm_game.sh",
+      "devices": [
+        "TRIMUI_BRICK",
+        "TRIMUI_SMART_PRO",
+        "TRIMUI_SMART_PRO_S"
+      ]
     }
   ],
   "menuOptions": {

--- a/Emu/SCUMMVM/scan_scummvm_game.sh
+++ b/Emu/SCUMMVM/scan_scummvm_game.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# /mnt/SDCARD/Emu/SCUMMVM/scan_scummvm_game.sh
+
+# Trigger for the smart scan function
+export RUN_SCUMMVM_SCAN=true
+
+# Launch the main controller with a dummy argument to satisfy the launcher's logic
+exec /mnt/SDCARD/Emu/SCUMMVM/../../spruce/scripts/emu/standard_launch.sh "$@"

--- a/spruce/scripts/emu/lib/scummvm_functions.sh
+++ b/spruce/scripts/emu/lib/scummvm_functions.sh
@@ -1,15 +1,7 @@
 #!/bin/sh
 
 # Requires globals: EMU_DIR, ROM_FILE, PLATFORM, CORE, LOG_DIR
-# Provides: run_scummvm, run_scummvm_menu, prepare_scummvm_bin
-
-prepare_scummvm_bin() {
-    case "$PLATFORM" in
-        "SmartProS")        SCUMMVM_BIN="$EMU_DIR/scummvm_a523" ;;
-        "SmartPro"|"Brick") SCUMMVM_BIN="$EMU_DIR/scummvm_a133p" ;;
-        *)                  SCUMMVM_BIN="$EMU_DIR/scummvm" ;;
-    esac
-}
+# Provides: run_scummvm, run_scummvm_menu, run_scummvm_scan
 
 run_scummvm_menu() {
 	export HOME="/mnt/SDCARD/Saves/"
@@ -39,15 +31,15 @@ run_scummvm_menu() {
 
 	case "$PLATFORM" in
 		"SmartProS")
-			SCUMMVM_BIN="./scummvm_a523"
+			SCUMMVM_BIN="$EMU_DIR/scummvm_a523"
 			export LD_LIBRARY_PATH="$EMU_DIR/lib_a523:$LD_LIBRARY_PATH"
 			;;
 		"SmartPro"|"Brick")
-			SCUMMVM_BIN="./scummvm_a133p"
+			SCUMMVM_BIN="$EMU_DIR/scummvm_a133p"
 			export LD_LIBRARY_PATH="$EMU_DIR/lib_a133p:$LD_LIBRARY_PATH"
 			;;
 		*)
-			SCUMMVM_BIN="./scummvm"
+			SCUMMVM_BIN="$EMU_DIR/scummvm"
 			export LD_LIBRARY_PATH="$EMU_DIR/lib:$LD_LIBRARY_PATH"
 			;;
 	esac
@@ -75,7 +67,6 @@ run_scummvm() {
 		mkdir -p "$SAVE_DIR"
 	fi
 
-	# Check and copy default config if platform-specific config doesn't exist
 	if [ ! -f "$SCUMMVM_CONFIG" ]; then
 			DEFAULT_CONFIG="$EMU_DIR/.config/scummvm/scummvm.ini"
 		if [ -f "$DEFAULT_CONFIG" ]; then
@@ -89,15 +80,15 @@ run_scummvm() {
 
 	case "$PLATFORM" in
 		"SmartProS")
-			SCUMMVM_BIN="./scummvm_a523"
+			SCUMMVM_BIN="$EMU_DIR/scummvm_a523"
 			export LD_LIBRARY_PATH="$EMU_DIR/lib_a523:$LD_LIBRARY_PATH"
 			;;
 		"SmartPro"|"Brick")
-			SCUMMVM_BIN="./scummvm_a133p"
+			SCUMMVM_BIN="$EMU_DIR/scummvm_a133p"
 			export LD_LIBRARY_PATH="$EMU_DIR/lib_a133p:$LD_LIBRARY_PATH"
 			;;
 		*)
-			SCUMMVM_BIN="./scummvm"
+			SCUMMVM_BIN="$EMU_DIR/scummvm"
 			export LD_LIBRARY_PATH="$EMU_DIR/lib:$LD_LIBRARY_PATH"
 			;;
 	esac
@@ -115,17 +106,92 @@ run_scummvm() {
 			DATA_PATH="$(dirname "$ROM_FILE")"
 		fi
 
-		# Extract game ID from file content (if not a .launch file)
-		if [ "${romName##*.}" != "launch" ]; then
-			game_id=$(cat "$ROM_FILE" | tr -d '\r\n' | xargs)
-		fi
-		
 		# Use filename as fallback game ID
+		game_id=$(cat "$ROM_FILE" | tr -d '\r\n' | xargs)
 		[ -z "$game_id" ] && game_id="$romNameNoExt"
-
+		
 		# Execute ScummVM
 		export CURL_CA_BUNDLE="$EMU_DIR/cacert.pem"
 		export SSL_CERT_FILE="$EMU_DIR/cacert.pem"
 		"$SCUMMVM_BIN" --config="$SCUMMVM_CONFIG" --path="$DATA_PATH" "$game_id" > "$SCUMMVM_LOG" 2>&1
 	fi
+}
+
+run_scummvm_scan() {
+	export HOME="/mnt/SDCARD/Saves/"
+
+	SCUMMVM_CONFIG="/mnt/SDCARD/Saves/.config/scummvm/scummvm.ini"
+	SCAN_LOG="${LOG_DIR}/scummvm-scan.log"
+	ROM_DIR="/mnt/SDCARD/Roms/SCUMMVM"
+
+	# For cases where the scan is run for the first time before launching the game or opening the menu.
+	if [ ! -f "$SCUMMVM_CONFIG" ]; then
+		DEFAULT_CONFIG="$EMU_DIR/.config/scummvm/scummvm.ini"
+		if [ -f "$DEFAULT_CONFIG" ]; then
+			DEST_DIR=$(dirname "$SCUMMVM_CONFIG")
+			[ ! -d "$DEST_DIR" ] && mkdir -p "$DEST_DIR"
+			cp "$DEFAULT_CONFIG" "$SCUMMVM_CONFIG"
+		fi
+	fi
+
+	case "$PLATFORM" in
+		"SmartProS")
+			SCUMMVM_BIN="$EMU_DIR/scummvm_a523"
+			export LD_LIBRARY_PATH="$EMU_DIR/lib_a523:$LD_LIBRARY_PATH"
+			;;
+		"SmartPro"|"Brick")
+			SCUMMVM_BIN="$EMU_DIR/scummvm_a133p"
+			export LD_LIBRARY_PATH="$EMU_DIR/lib_a133p:$LD_LIBRARY_PATH"
+			;;
+		*)
+			SCUMMVM_BIN="$EMU_DIR/scummvm"
+			export LD_LIBRARY_PATH="$EMU_DIR/lib:$LD_LIBRARY_PATH"
+			;;
+	esac
+
+    cd "$ROM_DIR" || return 1
+    
+    for dir in */; do
+        [ -d "$dir" ] || continue
+        dirName=${dir%/}
+        [ "$dirName" = "Imgs" ] && continue 
+
+        targetFile="${dirName}.scummvm"
+        full_path="$ROM_DIR/$dirName"
+
+        # [Dual-Check Logic]
+        if [ -s "$targetFile" ]; then
+            current_id=$(cat "$targetFile" | tr -d '\r\n ' | xargs)
+            if grep -q "\[$current_id\]" "$SCUMMVM_CONFIG" 2>/dev/null; then
+                echo "SKIP: $targetFile (ID: $current_id) is already registered." >> "$SCAN_LOG"
+                continue
+            fi
+        fi
+
+        echo "Scanning Folder: $dirName" >> "$SCAN_LOG"
+        engine_out=$("$SCUMMVM_BIN" --config="$SCUMMVM_CONFIG" --path="$full_path" --add 2>&1 | tee -a "$SCAN_LOG")
+
+        # [Search Stage 1 & 2] Extract primary ID
+        game_id=$(echo "$engine_out" | grep "Target:" | awk '{print $2}' | head -n 1)
+        if [ -z "$game_id" ]; then
+            game_id=$(echo "$engine_out" | sed -n 's/.*Found [^:]*:\([^,]*\), but has already been added.*/\1/p')
+        fi
+
+        # [Search Stage 3: The Head Strategy]
+        # Use 'head -n 1' to get the cleanest first ID (monkey)
+        if [ -n "$game_id" ] || [ -f "$SCUMMVM_CONFIG" ]; then
+            # Narrow the range with -B 5, and fish for the topmost pure ID with head -n 1.
+            actual_id=$(grep -B 5 "path=$full_path" "$SCUMMVM_CONFIG" | grep "\[" | grep -v "\[scummvm\]" | head -n 1 | tr -d '[]' | tr -d '\r\n ')
+            [ -n "$actual_id" ] && game_id="$actual_id"
+        fi
+
+        # Final Action: Write CLEAN Game ID to .scummvm file
+        if [ -n "$game_id" ]; then
+            echo "$game_id" | tr -d '\r\n ' > "$targetFile"
+            echo "RESULT: Successfully registered [$game_id] to $targetFile" >> "$SCAN_LOG"
+        fi
+    done
+
+    sync
+    echo "--- ScummVM Smart Scan Completed: $(date) ---" >> "$SCAN_LOG"
 }

--- a/spruce/scripts/emu/standard_launch.sh
+++ b/spruce/scripts/emu/standard_launch.sh
@@ -132,6 +132,8 @@ case $EMU_NAME in
 		. /mnt/SDCARD/spruce/scripts/emu/lib/scummvm_functions.sh
 		if [ "$OPEN_SCUMMVM_MENU" = "true" ]; then
 			run_scummvm_menu
+		elif [ "$RUN_SCUMMVM_SCAN" = "true" ]; then
+			run_scummvm_scan
 		elif [ "$CORE" = "scummvm-standalone" ]; then
 			run_scummvm
 		else


### PR DESCRIPTION
The ScummVM scanner automatically registers games in the Scummvm Launcher. It automatically creates {GameFolderName}.scummvm and inserts the target_name into it (e.g., monkey, tentacle, 5daysastranger ...). /mnt/SDCARD/Saves/spruce/scummvm-scan.log (You can check the scanner's results here.) Multiple games can be registered to the launcher by a single GameFolder. (e.g., monkey / monkey-fm / monkey-sega )
 but even in such cases, only one ID will be written to {GameFolderName}.scummvm. (e.g., monkey )
 However, you must manually delete all but one game from the launcher.
(There's no problem if you don't erase it, but... it would be easier to set them up if you want to distinguish which objects are running from your gamelist.)