### PR TITLE
Fix WiFi not connecting on boot for TSP/Brick

### DIFF
--- a/App/PyUI/main-ui/devices/trimui/trim_ui_brick.py
+++ b/App/PyUI/main-ui/devices/trimui/trim_ui_brick.py
@@ -68,6 +68,10 @@ class TrimUIBrick(TrimUIDevice):
         self._set_saturation_to_config()
         self._set_brightness_to_config()
         self._set_hue_to_config()
+        if include_wifi and self.is_wifi_enabled():
+            if not self.connection_seems_up():
+                self.stop_wifi_services()
+            self.start_wifi_services()
             
     #Untested
     @throttle.limit_refresh(5)

--- a/App/PyUI/main-ui/devices/trimui/trim_ui_smart_pro.py
+++ b/App/PyUI/main-ui/devices/trimui/trim_ui_smart_pro.py
@@ -64,6 +64,10 @@ class TrimUISmartPro(TrimUIDevice):
         self._set_saturation_to_config()
         self._set_brightness_to_config()
         self._set_hue_to_config()
+        if include_wifi and self.is_wifi_enabled():
+            if not self.connection_seems_up():
+                self.stop_wifi_services()
+            self.start_wifi_services()
 
     #Untested
     @throttle.limit_refresh(5)


### PR DESCRIPTION
## Summary
- TSP and Brick `startup_init()` only set display settings — WiFi was never proactively started, unlike the Flip which calls `start_wifi_services()` during init
- This meant WiFi relied on the shell-side background job plus the passive `monitor_wifi` 10-second poll loop, which could take up to ~60 seconds to react if something went wrong
- Now matches Flip behavior: if WiFi is enabled, stops stale services and starts fresh during `startup_init()`