### PR TITLE
ScummVM sync game database across devices

### DIFF
--- a/Emu/SCUMMVM/config.json
+++ b/Emu/SCUMMVM/config.json
@@ -43,6 +43,25 @@
         "MIYOO_MINI_PLUS",
         "MIYOO_MINI_FLIP"
       ]
+    },
+    {
+      "name": "Sync ScummVM Game ID",
+      "launch": "/mnt/SDCARD/Emu/SCUMMVM/sync_game_id.sh",
+      "devices": [
+        "TRIMUI_BRICK",
+        "TRIMUI_SMART_PRO",
+        "TRIMUI_SMART_PRO_S",
+        "MIYOO_FLIP",
+        "MIYOO_A30",
+        "GKD_PIXEL2",
+        "ANBERNIC_RG34XXSP",
+        "ANBERNIC_RG28XX",
+        "ANBERNIC_RGXX640480",
+        "MIYOO_MINI",
+        "MIYOO_MINI_V4",
+        "MIYOO_MINI_PLUS",
+        "MIYOO_MINI_FLIP"
+      ]
     }
   ],
   "menuOptions": {

--- a/Emu/SCUMMVM/sync_game_id.sh
+++ b/Emu/SCUMMVM/sync_game_id.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# /mnt/SDCARD/Emu/SCUMMVM/sync_game_id.sh
+
+# Trigger for sync game id
+export SYNC_GAME_ID=true
+
+# Launch the main controller with a dummy argument to satisfy the launcher's logic
+exec /mnt/SDCARD/Emu/SCUMMVM/../../spruce/scripts/emu/standard_launch.sh "$@"

--- a/spruce/scripts/emu/lib/scummvm_functions.sh
+++ b/spruce/scripts/emu/lib/scummvm_functions.sh
@@ -66,99 +66,73 @@ _set_scummvm_platform() {
 			;;
 	esac
 
-	# Copy default config if user config doesn't exist yet
-	if [ ! -f "$SCUMMVM_CONFIG" ]; then
-		if [ -f "$DEFAULT_CONFIG" ]; then
-			DEST_DIR=$(dirname "$SCUMMVM_CONFIG")
-			if [ ! -d "$DEST_DIR" ]; then
-				mkdir -p "$DEST_DIR"
-			fi
-			cp "$DEFAULT_CONFIG" "$SCUMMVM_CONFIG"
+	# Copy default config if user config doesn't exist yet (for all platforms)
+	for target in a30 anbernic brick flip mini pixel2 tsp tsps; do
+		T_PATH="/mnt/SDCARD/Saves/.config/scummvm-$target/scummvm.ini"
+		S_PATH="/mnt/SDCARD/Emu/SCUMMVM/.config/scummvm-$target/scummvm.ini"
+
+		if [ ! -f "$T_PATH" ] && [ -f "$S_PATH" ]; then
+			mkdir -p "$(dirname "$T_PATH")"
+			cp "$S_PATH" "$T_PATH"
 		fi
+	done
+
+	SAVE_DIR="/mnt/SDCARD/Saves/saves/scummvm-sa"
+	if [ ! -d "$SAVE_DIR" ]; then
+		mkdir -p "$SAVE_DIR"
 	fi
 }
 
 run_scummvm_menu() {
 	export HOME="/mnt/SDCARD/Saves/"
 	cd "$EMU_DIR"
-
+	# ROM_FILE, CORE not present 
 	SCUMMVM_LOG="${LOG_DIR}/scummvm-standalone-${PLATFORM}.log"
-
 	export SDL_GAMECONTROLLERCONFIG_FILE="$EMU_DIR/gamecontrollerdb.txt"
-
-	SAVE_DIR="/mnt/SDCARD/Saves/saves/scummvm-sa"
-
-	if [ ! -d "$SAVE_DIR" ]; then
-		mkdir -p "$SAVE_DIR"
-	fi
 
 	_set_scummvm_platform
 
-	if [ -f "$SCUMMVM_BIN" ]; then
-		export CURL_CA_BUNDLE="$EMU_DIR/cacert.pem"
-		export SSL_CERT_FILE="$EMU_DIR/cacert.pem"
-
-
-		"$SCUMMVM_BIN" --config="$SCUMMVM_CONFIG" > "$SCUMMVM_LOG" 2>&1
-
-		[ "$SCUMMVM_BRICK_JOYSTICK" = "1" ] && rm -f /tmp/trimui_inputd/input_no_dpad /tmp/trimui_inputd/input_dpad_to_joystick
-	fi
+	export CURL_CA_BUNDLE="$EMU_DIR/cacert.pem"
+	export SSL_CERT_FILE="$EMU_DIR/cacert.pem"
+	"$SCUMMVM_BIN" --config="$SCUMMVM_CONFIG" > "$SCUMMVM_LOG" 2>&1
+	[ "$SCUMMVM_BRICK_JOYSTICK" = "1" ] && rm -f /tmp/trimui_inputd/input_no_dpad /tmp/trimui_inputd/input_dpad_to_joystick
 }
 
 run_scummvm() {
 	export HOME="/mnt/SDCARD/Saves/"
 	cd "$EMU_DIR"
-
 	SCUMMVM_LOG="${LOG_DIR}/${CORE}-${PLATFORM}.log"
-
 	export SDL_GAMECONTROLLERCONFIG_FILE="$EMU_DIR/gamecontrollerdb.txt"
-
-	SCUMMVM_LOG="${LOG_DIR}/${CORE}-${PLATFORM}.log"
-	SAVE_DIR="/mnt/SDCARD/Saves/saves/scummvm-sa"
-
-	if [ ! -d "$SAVE_DIR" ]; then
-		mkdir -p "$SAVE_DIR"
-	fi
 
 	_set_scummvm_platform
 
-	if [ -f "$SCUMMVM_BIN" ]; then
-		# Parse ROM filename
-		romName=$(basename "$ROM_FILE")
-		romNameNoExt=${romName%.*}
-
-		# Correct data path: look for a folder with the same name as the .scummvm file
-		DATA_PATH="$(dirname "$ROM_FILE")/$romNameNoExt"
-
-		# Fallback to parent directory if folder does not exist
-		if [ ! -d "$DATA_PATH" ]; then
-			DATA_PATH="$(dirname "$ROM_FILE")"
-		fi
-
-		# Use filename as fallback game ID
-		game_id=$(cat "$ROM_FILE" | tr -d '\r\n' | xargs)
-		[ -z "$game_id" ] && game_id="$romNameNoExt"
-
-		# Execute ScummVM
-		export CURL_CA_BUNDLE="$EMU_DIR/cacert.pem"
-		export SSL_CERT_FILE="$EMU_DIR/cacert.pem"
-
-
-		# Auto-load from autosave slot 0 if a save exists
-		SAVE_SLOT_ARG=""
-		if [ -f "$SAVE_DIR/$game_id.s00" ]; then
-			SAVE_SLOT_ARG="--save-slot=0"
-		fi
-
-		"$SCUMMVM_BIN" --config="$SCUMMVM_CONFIG" $SAVE_SLOT_ARG --path="$DATA_PATH" "$game_id" > "$SCUMMVM_LOG" 2>&1
-
-		[ "$SCUMMVM_BRICK_JOYSTICK" = "1" ] && rm -f /tmp/trimui_inputd/input_no_dpad /tmp/trimui_inputd/input_dpad_to_joystick
+	# Parse ROM filename
+	romName=$(basename "$ROM_FILE")
+	romNameNoExt=${romName%.*}
+	# Correct data path: look for a folder with the same name as the .scummvm file
+	DATA_PATH="$(dirname "$ROM_FILE")/$romNameNoExt"
+	# Fallback to parent directory if folder does not exist
+	if [ ! -d "$DATA_PATH" ]; then
+		DATA_PATH="$(dirname "$ROM_FILE")"
 	fi
+	# Use filename as fallback game ID
+	game_id=$(cat "$ROM_FILE" | tr -d '\r\n' | xargs)
+	[ -z "$game_id" ] && game_id="$romNameNoExt"
+
+	# Execute ScummVM
+	export CURL_CA_BUNDLE="$EMU_DIR/cacert.pem"
+	export SSL_CERT_FILE="$EMU_DIR/cacert.pem"
+	# Auto-load from autosave slot 0 if a save exists
+	SAVE_SLOT_ARG=""
+	if [ -f "$SAVE_DIR/$game_id.s00" ]; then
+		SAVE_SLOT_ARG="--save-slot=0"
+	fi
+	"$SCUMMVM_BIN" --config="$SCUMMVM_CONFIG" $SAVE_SLOT_ARG --path="$DATA_PATH" "$game_id" > "$SCUMMVM_LOG" 2>&1
+	[ "$SCUMMVM_BRICK_JOYSTICK" = "1" ] && rm -f /tmp/trimui_inputd/input_no_dpad /tmp/trimui_inputd/input_dpad_to_joystick
 }
 
 run_scummvm_scan() {
 	export HOME="/mnt/SDCARD/Saves/"
-
 	SCAN_LOG="${LOG_DIR}/scummvm-scan.log"
 	ROM_DIR="/mnt/SDCARD/Roms/SCUMMVM"
 
@@ -167,50 +141,72 @@ run_scummvm_scan() {
 	start_pyui_message_writer
 	display_image_and_text "/mnt/SDCARD/Emu/SCUMMVM/scummvm.png" 35 25 "Scanning Games.........." 75
 
-    cd "$ROM_DIR" || return 1
+	cd "$ROM_DIR" || return 1
+	
+	for dir in */; do
+		[ -d "$dir" ] || continue
+		dirName=${dir%/}
+		[ "$dirName" = "Imgs" ] && continue 
+	
+		targetFile="${dirName}.scummvm"
+		full_path="$ROM_DIR/$dirName"
+	
+		# [Dual-Check Logic]
+		if [ -s "$targetFile" ]; then
+			current_id=$(cat "$targetFile" | tr -d '\r\n ' | xargs)
+			if grep -q "\[$current_id\]" "$SCUMMVM_CONFIG" 2>/dev/null; then
+				echo "SKIP: $targetFile (ID: $current_id) is already registered." >> "$SCAN_LOG"
+				continue
+			fi
+		fi
+	
+		echo "Scanning Folder: $dirName" >> "$SCAN_LOG"
+		engine_out=$("$SCUMMVM_BIN" --config="$SCUMMVM_CONFIG" --path="$full_path" --add 2>&1 | tee -a "$SCAN_LOG")
+	
+		# [Search Stage 1 & 2] Extract primary ID
+		game_id=$(echo "$engine_out" | grep "Target:" | awk '{print $2}' | head -n 1)
+		if [ -z "$game_id" ]; then
+			game_id=$(echo "$engine_out" | sed -n 's/.*Found [^:]*:\([^,]*\), but has already been added.*/\1/p')
+		fi
+	
+		# [Search Stage 3: The Head Strategy]
+		# Use 'head -n 1' to get the cleanest first ID (monkey)
+		if [ -n "$game_id" ] || [ -f "$SCUMMVM_CONFIG" ]; then
+			# Narrow the range with -B 5, and fish for the topmost pure ID with head -n 1.
+			actual_id=$(grep -B 5 "path=$full_path" "$SCUMMVM_CONFIG" | grep "\[" | grep -v "\[scummvm\]" | head -n 1 | tr -d '[]' | tr -d '\r\n ')
+			[ -n "$actual_id" ] && game_id="$actual_id"
+		fi
+	
+		# Final Action: Write CLEAN Game ID to .scummvm file
+		if [ -n "$game_id" ]; then
+			echo "$game_id" | tr -d '\r\n ' > "$targetFile"
+			echo "RESULT: Successfully registered [$game_id] to $targetFile" >> "$SCAN_LOG"
+		fi
+	done
+	
+	sync
+	echo "--- ScummVM Smart Scan Completed: $(date) ---" >> "$SCAN_LOG"
+}
 
-    for dir in */; do
-        [ -d "$dir" ] || continue
-        dirName=${dir%/}
-        [ "$dirName" = "Imgs" ] && continue
-
-        targetFile="${dirName}.scummvm"
-        full_path="$ROM_DIR/$dirName"
-
-        # [Dual-Check Logic]
-        if [ -s "$targetFile" ]; then
-            current_id=$(cat "$targetFile" | tr -d '\r\n ' | xargs)
-            if grep -q "\[$current_id\]" "$SCUMMVM_CONFIG" 2>/dev/null; then
-                echo "SKIP: $targetFile (ID: $current_id) is already registered." >> "$SCAN_LOG"
-                continue
-            fi
-        fi
-
-        echo "Scanning Folder: $dirName" >> "$SCAN_LOG"
-        engine_out=$("$SCUMMVM_BIN" --config="$SCUMMVM_CONFIG" --path="$full_path" --add 2>&1 | tee -a "$SCAN_LOG")
-
-        # [Search Stage 1 & 2] Extract primary ID
-        game_id=$(echo "$engine_out" | grep "Target:" | awk '{print $2}' | head -n 1)
-        if [ -z "$game_id" ]; then
-            game_id=$(echo "$engine_out" | sed -n 's/.*Found [^:]*:\([^,]*\), but has already been added.*/\1/p')
-        fi
-
-        # [Search Stage 3: The Head Strategy]
-        # Use 'head -n 1' to get the cleanest first ID (monkey)
-        if [ -n "$game_id" ] || [ -f "$SCUMMVM_CONFIG" ]; then
-            # Narrow the range with -B 5, and fish for the topmost pure ID with head -n 1.
-            actual_id=$(grep -B 5 "path=$full_path" "$SCUMMVM_CONFIG" | grep "\[" | grep -v "\[scummvm\]" | head -n 1 | tr -d '[]' | tr -d '\r\n ')
-            [ -n "$actual_id" ] && game_id="$actual_id"
-        fi
-
-        # Final Action: Write CLEAN Game ID to .scummvm file
-        if [ -n "$game_id" ]; then
-            echo "$game_id" | tr -d '\r\n ' > "$targetFile"
-            echo "RESULT: Successfully registered [$game_id] to $targetFile" >> "$SCAN_LOG"
-        fi
-    done
-
-    sync
-    echo "--- ScummVM Smart Scan Completed: $(date) ---" >> "$SCAN_LOG"
-	stop_pyui_message_writer
+sync_game_id() {
+	_set_scummvm_platform
+	[ ! -f "$SCUMMVM_CONFIG" ] && return
+	
+	start_pyui_message_writer 2>/dev/null
+	display_image_and_text "/mnt/SDCARD/Emu/SCUMMVM/scummvm.png" 35 25 "Syncing Game Database..." 75
+	
+	local NEW_GAME_DATA=$(awk 'BEGIN {RS="["; FS="\n"} NR>1 { if ($0 ~ /gameid=/ && $0 ~ /path=/) printf "[%s", $0 }' "$SCUMMVM_CONFIG")
+	
+	for target in a30 anbernic brick flip mini pixel2 tsp tsps; do
+		local T_INI="/mnt/SDCARD/Saves/.config/scummvm-$target/scummvm.ini"
+		
+		if [ -f "$T_INI" ] && [ "$T_INI" != "$SCUMMVM_CONFIG" ]; then
+			local TARGET_SYSTEM_ONLY=$(awk 'BEGIN {RS="["; FS="\n"} NR>1 { if (!($0 ~ /gameid=/ && $0 ~ /path=/)) printf "[%s", $0 }' "$T_INI")
+			printf "%s\n\n%s" "$TARGET_SYSTEM_ONLY" "$NEW_GAME_DATA" > "$T_INI"
+			sed -i '/^$/N;/^\n$/D' "$T_INI"
+		fi
+	done
+	
+	sync
+	stop_pyui_message_writer 2>/dev/null
 }

--- a/spruce/scripts/emu/standard_launch.sh
+++ b/spruce/scripts/emu/standard_launch.sh
@@ -151,6 +151,8 @@ case $EMU_NAME in
 			run_scummvm_menu
 		elif [ "$RUN_SCUMMVM_SCAN" = "true" ]; then
 			run_scummvm_scan
+		elif [ "$SYNC_GAME_ID" = "true" ]; then
+			sync_game_id
 		elif [ "$CORE" = "scummvm-standalone" ]; then
 			run_scummvm
 		else


### PR DESCRIPTION
Upon initial launch, the default scummvm.ini for all devices is copied to the user config area (Saves/.config/). A feature has been added to the X-menu to Sync scummvm.ini across devices.  After completing scanning and detailed modifications on one device, syncing transfers only the game information to the ini files of all other devices.