### PR TITLE
Add option to run custom commands on spruce config value changes

### DIFF
--- a/App/PyUI/main-ui/utils/cfw_system_config.py
+++ b/App/PyUI/main-ui/utils/cfw_system_config.py
@@ -1,6 +1,8 @@
 import json
 import subprocess
 
+from utils.logger import PyUiLogger
+
 class CfwSystemConfig():
     _data = {}
     _config_path = None
@@ -43,6 +45,7 @@ class CfwSystemConfig():
         """Return a specific menu option by category and name, or None if not found."""
         return cls._data.get('menuOptions', {}).get(category, {}).get(name)
 
+
     @classmethod
     def set_menu_option(cls, category, name, selected_value):
         """
@@ -50,22 +53,22 @@ class CfwSystemConfig():
         """
         menu_options = cls._data.get('menuOptions', {}).get(category, {})
         if name in menu_options:
-            menu_options[name]['selected'] = selected_value
+            option = menu_options[name]
+
+            option['selected'] = selected_value
+
+            change_cmd = option.get('changeCmd')
+            if change_cmd:
+                try:
+                    subprocess.run(change_cmd, shell=True, check=True)
+                except Exception as e:
+                    PyUiLogger.get_logger().error(f"Command failed: {change_cmd} -> {e}")
+
             cls.save_config()
             cls.reload_config()
-            if name == "customThermals":
-                profile = selected_value.lower()
-                try:
-                    with open("/mnt/SDCARD/spruce/smartpros/etc/thermal-watchdog/active_profile", "w") as f:
-                        f.write(profile + "\n")
-                    if subprocess.run(["pgrep", "-x", "thermal-watchdog"], capture_output=True).returncode != 0:
-                        subprocess.Popen(["/mnt/SDCARD/spruce/smartpros/bin/thermal-watchdog"])
-                except Exception:
-                    pass
         else:
             # Optional: log or raise if not found
             pass
-
     @classmethod
     def get_selected_value(cls, category, name):
         """Return the selected value of a menu option, or None if not found."""

--- a/Saves/spruce/spruce-config.json
+++ b/Saves/spruce/spruce-config.json
@@ -294,6 +294,7 @@
                     "Smart",
                     "Sport"
                 ],
+                "changeCmd":"/mnt/SDCARD/spruce/smartpros/bin/update-thermal-watchdog-to-setting",
                 "selected": "Smart"
             }
         },

--- a/spruce/smartpros/bin/update-thermal-watchdog-to-setting
+++ b/spruce/smartpros/bin/update-thermal-watchdog-to-setting
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Load helper functions (provides get_config_value)
+. /mnt/SDCARD/spruce/scripts/helperFunctions.sh
+
+CONFIG_PATH="/mnt/SDCARD/Saves/spruce/spruce-config.json"
+PROFILE_PATH="/mnt/SDCARD/spruce/smartpros/etc/thermal-watchdog/active_profile"
+WATCHDOG_BIN="/mnt/SDCARD/spruce/smartpros/bin/thermal-watchdog"
+
+# Get selected value (default = Smart)
+option="$(get_config_value '.menuOptions."System Settings".customThermals.selected' "Smart")"
+
+# Convert to lowercase
+profile="$(printf '%s' "$option" | tr '[:upper:]' '[:lower:]')"
+
+# Write profile (safely)
+{
+    printf '%s\n' "$profile" > "$PROFILE_PATH"
+} 2>/dev/null
+
+# Check if thermal-watchdog is running
+if ! pgrep -x "thermal-watchdog" >/dev/null 2>&1; then
+    "$WATCHDOG_BIN" >/dev/null 2>&1 &
+fi


### PR DESCRIPTION
Remove hard-coded customThermals check in favor of a generic implementation that can be reused