### PR TITLE
PyUI: restore favorite flag marker across game-list views

### DIFF
--- a/App/PyUI/main-ui/menus/games/roms_menu_common.py
+++ b/App/PyUI/main-ui/menus/games/roms_menu_common.py
@@ -133,7 +133,8 @@ class RomsMenuCommon(ABC):
                         allow_scrolling_text=True, # roms select is allowed to scroll
                         full_screen_grid_resize_type=self.full_screen_grid_resize_type(),
                         image_resize_height_multiplier=self.get_image_resize_height_multiplier(),
-                        icon_and_desc_use_image_in_place_of_icon=True)
+                        icon_and_desc_use_image_in_place_of_icon=True,
+                        show_favorite_overlay=True)
 
     def _run_rom_selection(self, page_name):
         rom_list = self._get_rom_list()

--- a/App/PyUI/main-ui/views/carousel_view.py
+++ b/App/PyUI/main-ui/views/carousel_view.py
@@ -10,6 +10,7 @@ from controller.controller import Controller
 from display.resize_type import ResizeType
 from themes.theme import Theme
 from utils.py_ui_config import PyUiConfig
+from views.favorite_overlay import render_favorite_overlay
 from views.grid_or_list_entry import GridOrListEntry
 from views.selection import Selection
 from views.view import View
@@ -31,7 +32,8 @@ class CarouselView(View):
                   fixed_width=None,
                   fixed_selected_width=None,
                   selected_offset=None,
-                  use_selected_image_in_animation=None):
+                  use_selected_image_in_animation=None,
+                  show_favorite_overlay=False):
         super().__init__()
         self.resize_type = resize_type
         self.top_bar_text = top_bar_text
@@ -92,6 +94,7 @@ class CarouselView(View):
         self.include_index_text = True
         self.missing_image_path = missing_image_path
         self.skip_next_animation = False
+        self.show_favorite_overlay = show_favorite_overlay
 
 
     def set_options(self, options):
@@ -359,13 +362,21 @@ class CarouselView(View):
             else:
                 image = imageTextPair.get_image_path_ideal(widths[visible_index],Display.get_usable_screen_height())
 
-            self._render_image(image, 
-                                    x_offset, 
+            self._render_image(image,
+                                    x_offset,
                                     y_image_offset,
                                     render_mode,
                                     target_width=widths[visible_index],
                                     target_height=Display.get_usable_screen_height(),
                                     resize_type=self.resize_type)
+
+            if self.show_favorite_overlay:
+                render_favorite_overlay(imageTextPair,
+                                        x_offset,
+                                        y_image_offset,
+                                        render_mode,
+                                        widths[visible_index],
+                                        Display.get_usable_screen_height())
 
     def get_selected_option(self):
         if 0 <= self.selected < len(self.options):

--- a/App/PyUI/main-ui/views/descriptive_list_view.py
+++ b/App/PyUI/main-ui/views/descriptive_list_view.py
@@ -8,6 +8,7 @@ from display.render_mode import RenderMode
 from display.resize_type import ResizeType
 from themes.theme import Theme
 from utils.logger import PyUiLogger
+from views.favorite_overlay import render_favorite_overlay
 from views.grid_or_list_entry import GridOrListEntry
 from views.list_view import ListView
 from views.text_utils import TextUtils
@@ -16,9 +17,11 @@ class DescriptiveListView(ListView):
 
     def __init__(self, top_bar_text,
                  options: List[GridOrListEntry], selected_bg, selected : int = 0,
-                 icon_and_desc_use_image_in_place_of_icon=None):
+                 icon_and_desc_use_image_in_place_of_icon=None,
+                 show_favorite_overlay=False):
         super().__init__()
         self.icon_and_desc_use_image_in_place_of_icon = icon_and_desc_use_image_in_place_of_icon
+        self.show_favorite_overlay = show_favorite_overlay
         self.top_bar_text = top_bar_text
         self.set_options(options)
         self.selected : int = selected
@@ -90,13 +93,21 @@ class DescriptiveListView(ListView):
             if(not self.contains_any_icons):
                 target_icon_w = 0
             if(iconPath is not None):
-                icon_w, icon_h = Display.render_image(iconPath, 
-                                    row_offset_x + target_icon_w//2, 
+                icon_w, icon_h = Display.render_image(iconPath,
+                                    row_offset_x + target_icon_w//2,
                                     row_offset_y + self.each_entry_height//2,
-                                    render_mode = RenderMode.MIDDLE_CENTER_ALIGNED, 
-                                    target_width=target_icon_w, 
+                                    render_mode = RenderMode.MIDDLE_CENTER_ALIGNED,
+                                    target_width=target_icon_w,
                                     target_height=int(self.each_entry_height*0.90))
-                
+
+            if self.show_favorite_overlay and self.icon_and_desc_use_image_in_place_of_icon:
+                render_favorite_overlay(gridOrListEntry,
+                                        row_offset_x + target_icon_w//2,
+                                        row_offset_y + self.each_entry_height//2,
+                                        RenderMode.MIDDLE_CENTER_ALIGNED,
+                                        target_icon_w,
+                                        int(self.each_entry_height*0.90))
+
             icon_w = target_icon_w
 
             color = Theme.text_color_selected(FontPurpose.DESCRIPTIVE_LIST_TITLE) if actual_index == self.selected else Theme.text_color(FontPurpose.DESCRIPTIVE_LIST_TITLE)

--- a/App/PyUI/main-ui/views/favorite_overlay.py
+++ b/App/PyUI/main-ui/views/favorite_overlay.py
@@ -1,0 +1,49 @@
+from display.display import Display
+from display.render_mode import RenderMode
+from display.x_render_option import XRenderOption
+from display.y_render_option import YRenderOption
+from views.grid_or_list_entry import GridOrListEntry
+
+
+def render_favorite_overlay(entry: GridOrListEntry,
+                            image_x: int,
+                            image_y: int,
+                            image_render_mode: RenderMode,
+                            image_width,
+                            image_height):
+    if image_width is None or image_height is None:
+        return
+    if image_width <= 0 or image_height <= 0:
+        return
+
+    icon_path = entry.get_icon()
+    if icon_path is None:
+        return
+
+    if image_render_mode.x_mode == XRenderOption.LEFT:
+        image_right = image_x + image_width
+    elif image_render_mode.x_mode == XRenderOption.CENTER:
+        image_right = image_x + image_width // 2
+    else:
+        image_right = image_x
+
+    if image_render_mode.y_mode == YRenderOption.TOP:
+        image_top = image_y
+    elif image_render_mode.y_mode == YRenderOption.CENTER:
+        image_top = image_y - image_height // 2
+    else:
+        image_top = image_y - image_height
+
+    size = max(int(min(image_width, image_height) * 0.22), 16)
+    inset = size // 4
+    overlay_cx = image_right - size // 2 - inset
+    overlay_cy = image_top + size // 2 + inset
+
+    Display.render_image(
+        icon_path,
+        overlay_cx,
+        overlay_cy,
+        RenderMode.MIDDLE_CENTER_ALIGNED,
+        target_width=size,
+        target_height=size,
+    )

--- a/App/PyUI/main-ui/views/full_screen_grid_view.py
+++ b/App/PyUI/main-ui/views/full_screen_grid_view.py
@@ -10,6 +10,7 @@ from controller.controller import Controller
 from themes.theme import Theme
 from utils.logger import PyUiLogger
 from utils.py_ui_config import PyUiConfig
+from views.favorite_overlay import render_favorite_overlay
 from views.grid_or_list_entry import GridOrListEntry
 from views.selection import Selection
 from views.view import View
@@ -18,11 +19,12 @@ from views.view import View
 class FullScreenGridView(View):
     def __init__(self, top_bar_text, options: List[GridOrListEntry], selected_bg: str = None,
                  selected_index=0, show_grid_text=True,
-                 set_top_bar_text_to_selection=False, 
+                 set_top_bar_text_to_selection=False,
                  unselected_bg = None, missing_image_path=None,
                  resize_type = ResizeType.ZOOM,
                  render_text_overlay = True,
-                 image_resize_height_multiplier = None):
+                 image_resize_height_multiplier = None,
+                 show_favorite_overlay=False):
         super().__init__()
         if(render_text_overlay is None):
             render_text_overlay = True
@@ -74,6 +76,7 @@ class FullScreenGridView(View):
         self.render_bottom_bar_text_enabled = image_resize_height_multiplier != 1.0
         self.image_resize_height_multiplier = image_resize_height_multiplier
         self.y_rotate_instead = False
+        self.show_favorite_overlay = show_favorite_overlay
 
     def set_options(self, options):
         self.options = options
@@ -210,7 +213,15 @@ class FullScreenGridView(View):
                                     target_width=self.resized_width,
                                     target_height=self.resized_height,
                                     resize_type=self.resize_type)
-        
+
+        if self.show_favorite_overlay:
+            render_favorite_overlay(imageTextPair,
+                                    x_offset,
+                                    y_offset,
+                                    render_mode,
+                                    self.resized_width,
+                                    self.resized_height)
+
         if(render_text_overlay and (not self.set_top_bar_text_to_selection or self.image_resize_height_multiplier == 1.0)):
             self._render_shadowed_text(primary_text, Device.get_device().screen_height() * 0.68, FontPurpose.SHADOWED_BACKDROP, FontPurpose.SHADOWED, 25,text_alpha)
             self._render_shadowed_text(secondary_text, Device.get_device().screen_height() * 0.78, FontPurpose.SHADOWED_BACKDROP_SMALL, FontPurpose.SHADOWED_SMALL, 27,text_alpha)

--- a/App/PyUI/main-ui/views/grid_view.py
+++ b/App/PyUI/main-ui/views/grid_view.py
@@ -10,6 +10,7 @@ from display.y_render_option import YRenderOption
 from controller.controller import Controller
 from themes.theme import Theme
 from utils.py_ui_config import PyUiConfig
+from views.favorite_overlay import render_favorite_overlay
 from views.grid_or_list_entry import GridOrListEntry
 from views.selection import Selection
 from views.view import View
@@ -18,9 +19,9 @@ from views.view import View
 class GridView(View):
     def __init__(self, top_bar_text, options: List[GridOrListEntry], cols: int, rows: int, selected_bg: str = None,
                  selected_index=0, show_grid_text=True, resized_width=None, resized_height=None,
-                 set_top_bar_text_to_selection=False, set_bottom_bar_text_to_selection=False, resize_type=None, 
+                 set_top_bar_text_to_selection=False, set_bottom_bar_text_to_selection=False, resize_type=None,
                  unselected_bg = None, grid_img_y_offset=None, missing_image_path=None,
-                 wrap_around_single_row=None):
+                 wrap_around_single_row=None, show_favorite_overlay=False):
         super().__init__()
         self.resized_width = resized_width
         self.resized_height = resized_height
@@ -69,6 +70,7 @@ class GridView(View):
         self.usable_width = Device.get_device().screen_width() - (2 * self.x_pad)
         self.icon_width = self.usable_width / self.cols  # Initial icon width
         self.set_bg_offset_to_image_offset = Theme.grid_bg_offset_to_image_offset()
+        self.show_favorite_overlay = show_favorite_overlay
 
     def set_options(self, options):
         self.options = options
@@ -213,13 +215,23 @@ class GridView(View):
                          target_width=int(bg_width*1.05)if bg_width is not None else None,
                          target_height=int(bg_height*1.05)if bg_height is not None else None)
 
+        image_y = cell_y + img_offset // offset_divisor
         self._render_primary_image(image_path,
                          x_offset,
-                         cell_y + img_offset // offset_divisor,
+                         image_y,
                          render_mode,
                          target_width=self.resized_width,
                          target_height=self.resized_height,
                          resize_type=self.resize_type)
+
+        if self.show_favorite_overlay:
+            render_favorite_overlay(imageTextPair,
+                                    x_offset,
+                                    image_y,
+                                    render_mode,
+                                    self.resized_width,
+                                    self.resized_height)
+
         color = Theme.text_color_selected(
             self.font_purpose) if actual_index == self.selected else Theme.text_color(self.font_purpose)
 

--- a/App/PyUI/main-ui/views/view_creator.py
+++ b/App/PyUI/main-ui/views/view_creator.py
@@ -59,7 +59,8 @@ class ViewCreator:
                     carousel_use_selected_image_in_animation=None,
                     carousel_resize_type=None,
                     grid_view_wrap_around_single_row=None,
-                    icon_and_desc_use_image_in_place_of_icon=None) -> object:
+                    icon_and_desc_use_image_in_place_of_icon=None,
+                    show_favorite_overlay=False) -> object:
         
         if(len(options) == 0):
             return EmptyView()
@@ -80,7 +81,8 @@ class ViewCreator:
                     options=options,
                     selected=selected_index,
                     selected_bg=selected_bg,
-                    icon_and_desc_use_image_in_place_of_icon=icon_and_desc_use_image_in_place_of_icon
+                    icon_and_desc_use_image_in_place_of_icon=icon_and_desc_use_image_in_place_of_icon,
+                    show_favorite_overlay=show_favorite_overlay,
                 )
 
             case ViewType.TEXT_AND_IMAGE:
@@ -148,7 +150,7 @@ class ViewCreator:
                     img_width=img_width,
                     img_height=img_height,
                     selected_index=selected_index,
-                    show_icons=ImageListView.DONT_SHOW_ICONS,
+                    show_icons=ImageListView.SHOW_ICONS if show_favorite_overlay else ImageListView.DONT_SHOW_ICONS,
                     image_render_mode=image_render,
                     text_to_image_relationship=text_to_image_relationship,
                     selected_bg=Theme.get_list_small_selected_bg(),
@@ -199,7 +201,8 @@ class ViewCreator:
                     resize_type=grid_resize_type,
                     grid_img_y_offset=grid_img_y_offset,
                     missing_image_path=missing_image_path,
-                    wrap_around_single_row=grid_view_wrap_around_single_row
+                    wrap_around_single_row=grid_view_wrap_around_single_row,
+                    show_favorite_overlay=show_favorite_overlay,
                 )
 
             case ViewType.FULLSCREEN_GRID:
@@ -221,7 +224,8 @@ class ViewCreator:
                     missing_image_path=missing_image_path,
                     resize_type=full_screen_grid_resize_type,
                     render_text_overlay=full_screen_grid_render_text_overlay,
-                    image_resize_height_multiplier=image_resize_height_multiplier
+                    image_resize_height_multiplier=image_resize_height_multiplier,
+                    show_favorite_overlay=show_favorite_overlay,
                 )
             case ViewType.CAROUSEL:
                 return CarouselView(
@@ -243,7 +247,8 @@ class ViewCreator:
                     additional_y_offset=carousel_additional_y_offset,
                     selected_offset=carousel_selected_offset,
                     use_selected_image_in_animation=carousel_use_selected_image_in_animation,
-                    resize_type=carousel_resize_type
+                    resize_type=carousel_resize_type,
+                    show_favorite_overlay=show_favorite_overlay,
                 )
 
             case _:


### PR DESCRIPTION
## Summary
- Restores the favorite flag marker (`ic-favorite-mark.qoi`) that stopped rendering on game lists after PyUI commits `a44e40d11` (swap image to icon spot) and `b23f09bc4`.
- Adds an opt-in `show_favorite_overlay` flag threaded through `ViewCreator`; when set, the entry's `get_icon()` result is drawn in the top-right corner of the game image.
- Fixes grid, fullscreen-grid, carousel, descriptive-list (with image-in-icon slot), and text+image views — all of which were silently missing the marker.
- Only enabled for game lists (`roms_menu_common.py`); every other menu (system select, main menu, app menu, popups, etc.) is unchanged.

## Why this broke
`icon_searcher` on rom entries is wired to `_get_favorite_icon`, which returns `Theme.favorite_icon()` when a game is favorited. Before Feb 11, `DescriptiveListView` rendered `get_icon()` in its icon slot, so favorites were visible in that one view. After Chris's "image in icon slot" change, the box art took over the icon slot — and the other view types (grid / carousel / fullscreen / text+image) never called `get_icon()` at all. So across the board, the flag stopped rendering.

## Implementation notes
- New helper `views/favorite_overlay.py` computes the overlay position from any `RenderMode` (handles `CENTER`/`TOP`/`BOTTOM`/`LEFT`/`RIGHT`) and draws at ~22% of the smaller image dimension with a 1/4-size inset from the top-right corner.
- `ImageListView` already had a `show_icons` path that renders `get_icon()` next to the title; the fix just flips that to `SHOW_ICONS` when `show_favorite_overlay=True`, so no new overlay logic was needed there.
- `get_icon()` returns `None` when the entry isn't a favorite, so the overlay is a cheap no-op for non-favorites.

## Test plan
- [ ] Favorite a game; verify the flag appears in grid view
- [ ] Verify it appears in fullscreen grid view
- [ ] Verify it appears in carousel view
- [ ] Verify it appears in descriptive list view (both with and without game box art)
- [ ] Verify it appears next to the title in text+image view
- [ ] Verify non-game menus (system select, main menu, app menu) are visually unchanged
- [ ] Confirm on at least one theme with `ic-favorite-mark` defined (e.g. SPRUCE default, slantedv2) and one without