### PR TITLE
Detect if -p isn't supported for swap before trying it

### DIFF
--- a/spruce/scripts/set_up_swap.sh
+++ b/spruce/scripts/set_up_swap.sh
@@ -41,5 +41,13 @@ if [ ! -f "${SWAPFILE}" ]; then
     fi
 fi
 
-swapon -p 40 "${SWAPFILE}" || swapon "$SWAPFILE" || log_message "swapon command failed; proceeding without swap memory."
+case "$(swapon --help 2>&1)" in
+    *"-p"*)
+        swapon -p 40 "$SWAPFILE"
+        ;;
+    *)
+        swapon "$SWAPFILE"
+        ;;
+esac || log_message "swapon command failed; proceeding without swap memory."
+
 echo 10 > /proc/sys/vm/swappiness


### PR DESCRIPTION
Otherwise it can temporarily lockup swapon and result in swap not actually enabling