### PR TITLE
Fix shutdown-from-sleep timer mapping

### DIFF
--- a/spruce/scripts/platform/device_functions/utils/sleep_functions.sh
+++ b/spruce/scripts/platform/device_functions/utils/sleep_functions.sh
@@ -125,7 +125,7 @@ device_continue_sleep() {
     fi
 
     # Re-arm the wakealarm using earlier function
-    set_wake_alarm "$REMAINING" || return 1
+    set_wake_alarm "$REMAINING" "$WAKE_ALARM_PATH" || return 1
 
     # Go back to sleep
     trigger_device_sleep

--- a/spruce/scripts/sleep_helper.sh
+++ b/spruce/scripts/sleep_helper.sh
@@ -56,6 +56,7 @@ get_shutdown_timer() {
         "1m")    IDLE_TIMEOUT=60 ;;
         "2m")    IDLE_TIMEOUT=120 ;;
         "5m")    IDLE_TIMEOUT=300 ;;
+        "10m")   IDLE_TIMEOUT=600 ;;
         "15m")   IDLE_TIMEOUT=900 ;;
         "30m")   IDLE_TIMEOUT=1800 ;;
         "60m")   IDLE_TIMEOUT=3600 ;;
@@ -65,6 +66,7 @@ get_shutdown_timer() {
         "6h")    IDLE_TIMEOUT=21600 ;;
         "12h")   IDLE_TIMEOUT=43200 ;;
         "24h")   IDLE_TIMEOUT=86400 ;;
+        *)       IDLE_TIMEOUT=900 ;;
     esac
 
     echo "$IDLE_TIMEOUT"


### PR DESCRIPTION
Changed in fix/shutdown-from-sleep-timer, based on origin/Development:

spruce/scripts/sleep_helper.sh line 59: added the missing 10m -> 600 mapping for shutdownFromSleep.
spruce/scripts/sleep_helper.sh line 69: added a safe fallback to 15m instead of leaving unknown values at 0.
spruce/scripts/platform/device_functions/utils/sleep_functions.sh line 128: fixed device_continue_sleep so it passes WAKE_ALARM_PATH when re-arming the RTC wake alarm.
Root cause: dev source exposes 10m in Saves/spruce/spruce-config.json, but sleep_helper.sh did not handle that value. The timeout fell through to 0, so the wake check treated sleep as already expired and immediately started shutdown after wake.