### PR TITLE
Fix updater skip-version config key

### DIFF
--- a/App/-Updater/updater.py
+++ b/App/-Updater/updater.py
@@ -320,7 +320,7 @@ def main():
     developer_mode = flag_check("developer_mode")
     tester_mode = flag_check("tester_mode")
     skip_check = (developer_mode or tester_mode or
-        get_config_value('.menuOptions."Network Settings".otaskipVersionCheck.selected', "True") == "True")
+        get_config_value('.menuOptions."Network Settings".otaSkipVersionCheck.selected', "True") == "True")
     beta = "-beta" in update_file
 
     update_ver = parse_version(update_version)

--- a/App/-Updater/updater.sh
+++ b/App/-Updater/updater.sh
@@ -251,7 +251,7 @@ if flag_check "tester_mode"; then
 fi
 
 # Compare versions using awk
-SKIP_VERSION_CHECK="$(get_config_value '.menuOptions."Network Settings".otaskipVersionCheck.selected' "True")"
+SKIP_VERSION_CHECK="$(get_config_value '.menuOptions."Network Settings".otaSkipVersionCheck.selected' "True")"
 BETA_UPDATE=false
 
 if [ "$DEVELOPER_MODE" -eq 1 ] || [ "$TESTER_MODE" -eq 1 ]; then


### PR DESCRIPTION
Fixes the updater skip-version-check config lookup by using the existing otaSkipVersionCheck key instead of the misspelled otaskipVersionCheck.

The typo caused the updater to fall back to True, allowing older update archives to bypass the intended version gate and continue into archive validation.

Verified with the config contract unit test, Python static compile test, shell syntax check, and live device repro comparing clean nightly vs fixed branch overlay.