### PR TITLE
Fix SmartProS thermal command execution

### DIFF
--- a/spruce/scripts/platform/device_functions/SmartProS.sh
+++ b/spruce/scripts/platform/device_functions/SmartProS.sh
@@ -429,7 +429,7 @@ device_run_thermal_process(){
     selected="$(get_config_value '.menuOptions."System Settings".customThermals.selected' "Smart")"
 
     if [ "$selected" = "Adaptive" ]; then
-        python /mnt/SDCARD/spruce/scripts/platform/device_functions/utils/smartpros/adaptive_fan.py --lower 60 --upper 70 &
+        "$(get_python_path)" /mnt/SDCARD/spruce/scripts/platform/device_functions/utils/smartpros/adaptive_fan.py --lower 60 --upper 70 &
     else
         # Convert display name to lowercase profile name
         profile=$(echo "$selected" | tr 'A-Z' 'a-z')

--- a/spruce/smartpros/bin/update-thermal-watchdog-to-setting
+++ b/spruce/smartpros/bin/update-thermal-watchdog-to-setting
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Load helper functions (provides get_config_value)
+# Load helper functions (provides get_config_value and get_python_path)
 . /mnt/SDCARD/spruce/scripts/helperFunctions.sh
 
 CONFIG_PATH="/mnt/SDCARD/Saves/spruce/spruce-config.json"
@@ -17,7 +17,7 @@ pid=$(ps -eo pid,args | grep '[a]daptive_fan.py' | awk '{print $1}')
 [ -n "$pid" ] && kill "$pid"
 
 if [ "$option" = "Adaptive" ]; then
-    python "$ADAPTIVE_SCRIPT" --lower 60 --upper 70 &
+    "$(get_python_path)" "$ADAPTIVE_SCRIPT" --lower 60 --upper 70 &
 else
     # Convert to lowercase
     profile="$(printf '%s' "$option" | tr '[:upper:]' '[:lower:]')"


### PR DESCRIPTION
PyUI Thermal Control change command could fail on device because the setting helper shipped with incompatible line endings/non-executable source state, and Adaptive mode launched the fan controller through a non-resolved Python command.

Normalize the helper script, make it executable, and route both the setting-change helper and SmartProS startup path through get_python_path so the platform-provided Python runtime is used.