### PR TITLE
Fix SmartProS thermal command handoff

### DIFF
--- a/App/PyUI/main-ui/utils/cfw_system_config.py
+++ b/App/PyUI/main-ui/utils/cfw_system_config.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 import subprocess
 
 from utils.logger import PyUiLogger
@@ -57,14 +58,14 @@ class CfwSystemConfig():
 
             option['selected'] = selected_value
 
+            cls.save_config()
             change_cmd = option.get('changeCmd')
             if change_cmd:
                 try:
-                    subprocess.run(change_cmd, shell=True, check=True)
+                    command = shlex.split(change_cmd)
+                    subprocess.run(command + [str(selected_value)], check=True)
                 except Exception as e:
                     PyUiLogger.get_logger().error(f"Command failed: {change_cmd} -> {e}")
-
-            cls.save_config()
             cls.reload_config()
         else:
             # Optional: log or raise if not found

--- a/spruce/scripts/applySetting/customThermals.sh
+++ b/spruce/scripts/applySetting/customThermals.sh
@@ -1,18 +1,5 @@
 #!/bin/sh
 # Apply thermal control setting change immediately.
 # Called when the user changes the Thermal Control option in System Settings.
-# The thermal-watchdog picks up profile changes via inotify on active_profile.
 
-. /mnt/SDCARD/spruce/scripts/helperFunctions.sh
-
-THERMAL_PROFILE_DIR="/mnt/SDCARD/spruce/smartpros/etc/thermal-watchdog"
-
-selected="$(get_config_value '.menuOptions."System Settings".customThermals.selected' "Smart")"
-profile=$(echo "$selected" | tr 'A-Z' 'a-z')
-
-echo "$profile" > "$THERMAL_PROFILE_DIR/active_profile"
-
-# Start watchdog if not already running
-if ! pgrep -x thermal-watchdog >/dev/null 2>&1; then
-    /mnt/SDCARD/spruce/smartpros/bin/thermal-watchdog &
-fi
+exec /mnt/SDCARD/spruce/smartpros/bin/update-thermal-watchdog-to-setting "$@"

--- a/spruce/scripts/platform/device_functions/SmartProS.sh
+++ b/spruce/scripts/platform/device_functions/SmartProS.sh
@@ -425,17 +425,7 @@ device_stop_thermal_process(){
 }
 
 device_run_thermal_process(){
-    THERMAL_PROFILE_DIR="/mnt/SDCARD/spruce/smartpros/etc/thermal-watchdog"
-    selected="$(get_config_value '.menuOptions."System Settings".customThermals.selected' "Smart")"
-
-    if [ "$selected" = "Adaptive" ]; then
-        "$(get_python_path)" /mnt/SDCARD/spruce/scripts/platform/device_functions/utils/smartpros/adaptive_fan.py --lower 60 --upper 70 &
-    else
-        # Convert display name to lowercase profile name
-        profile=$(echo "$selected" | tr 'A-Z' 'a-z')
-        echo "$profile" > "$THERMAL_PROFILE_DIR/active_profile"
-        /mnt/SDCARD/spruce/smartpros/bin/thermal-watchdog &
-    fi
+    /mnt/SDCARD/spruce/smartpros/bin/update-thermal-watchdog-to-setting
 }
 
 set_backlight() {

--- a/spruce/smartpros/bin/update-thermal-watchdog-to-setting
+++ b/spruce/smartpros/bin/update-thermal-watchdog-to-setting
@@ -6,24 +6,67 @@
 CONFIG_PATH="/mnt/SDCARD/Saves/spruce/spruce-config.json"
 PROFILE_PATH="/mnt/SDCARD/spruce/smartpros/etc/thermal-watchdog/active_profile"
 WATCHDOG_BIN="/mnt/SDCARD/spruce/smartpros/bin/thermal-watchdog"
+PKILL_BIN="/mnt/SDCARD/spruce/smartpros/bin/pkill"
 ADAPTIVE_SCRIPT="/mnt/SDCARD/spruce/scripts/platform/device_functions/utils/smartpros/adaptive_fan.py"
 
-# Get selected value (default = Smart)
-option="$(get_config_value '.menuOptions."System Settings".customThermals.selected' "Smart")"
+stop_thermal_processes() {
+    "$PKILL_BIN" -f "$WATCHDOG_BIN" 2>/dev/null
+    pgrep -f '[a]daptive_fan.py' 2>/dev/null | while read -r pid; do
+        [ -n "$pid" ] && kill "$pid" 2>/dev/null
+    done
+}
 
-# Stop any running thermal process first
-killall thermal-watchdog 2>/dev/null
-pid=$(ps -eo pid,args | grep '[a]daptive_fan.py' | awk '{print $1}')
-[ -n "$pid" ] && kill "$pid"
+thermal_processes_running() {
+    pgrep -f "$WATCHDOG_BIN" >/dev/null 2>&1 && return 0
+    pgrep -f '[a]daptive_fan.py' >/dev/null 2>&1
+}
+
+wait_for_thermal_processes_to_stop() {
+    tries=0
+    while [ "$tries" -lt 10 ]; do
+        thermal_processes_running || return 0
+        sleep 0.1
+        tries=$((tries + 1))
+    done
+
+    "$PKILL_BIN" -9 -f "$WATCHDOG_BIN" 2>/dev/null
+    pgrep -f '[a]daptive_fan.py' 2>/dev/null | while read -r pid; do
+        [ -n "$pid" ] && kill -9 "$pid" 2>/dev/null
+    done
+
+    tries=0
+    while [ "$tries" -lt 5 ]; do
+        thermal_processes_running || return 0
+        sleep 0.1
+        tries=$((tries + 1))
+    done
+
+    return 1
+}
+
+write_active_profile() {
+    profile="$1"
+    tmp_profile="${PROFILE_PATH}.$$"
+    if printf '%s\n' "$profile" > "$tmp_profile" 2>/dev/null; then
+        mv "$tmp_profile" "$PROFILE_PATH"
+    else
+        rm -f "$tmp_profile"
+        exit 1
+    fi
+}
+
+# Prefer the caller's freshly selected value; fall back to saved config for boot/manual runs.
+option="${1:-}"
+[ -z "$option" ] && option="$(get_config_value '.menuOptions."System Settings".customThermals.selected' "Smart")"
+
+stop_thermal_processes
+wait_for_thermal_processes_to_stop || exit 1
 
 if [ "$option" = "Adaptive" ]; then
     "$(get_python_path)" "$ADAPTIVE_SCRIPT" --lower 60 --upper 70 &
 else
     # Convert to lowercase
     profile="$(printf '%s' "$option" | tr '[:upper:]' '[:lower:]')"
-
-    # Write profile (safely)
-    printf '%s\n' "$profile" > "$PROFILE_PATH" 2>/dev/null
-
+    write_active_profile "$profile"
     "$WATCHDOG_BIN" >/dev/null 2>&1 &
 fi


### PR DESCRIPTION
Pass the freshly selected thermal value into the SmartProS thermal updater instead of relying on a config re-read during immediate apply.

Centralize SmartProS thermal startup in the updater helper, make the PyUI applySetting shim delegate to it, and restart thermal control by stopping the old watchdog/adaptive process before writing the active profile and launching the selected controller.

Use the bundled full-cmdline pkill helper for thermal-watchdog because the binary name exceeds the Linux comm length used by killall.