### PR TITLE
Dispatch Brick Fn keys with a spruce-native watchdog

### DIFF
--- a/spruce/brick/fnkey_watchdog.sh
+++ b/spruce/brick/fnkey_watchdog.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Dispatch the Brick's two Fn keys by running the action the user picked in the
+# "Fn Key and Switch Settings" editor.
+#
+# On stock firmware the TrimUI keymon daemon reads the editor's per-key mapping
+# and runs the chosen action on each Fn press. spruce deliberately does not run
+# keymon (it replaced keymon everywhere with its own getevent watchdogs), so the
+# Fn keys did nothing. This watchdog is the spruce-native replacement for that
+# one job: watch the input node, and on an Fn key-down run the mapped action.
+#
+# Data model (all owned by the editor, /usr/trimui/apps/fn_editor/fneditor):
+#   /usr/trimui/fnkeys/f1key_launch  - one line, absolute path to the left  Fn action
+#   /usr/trimui/fnkeys/f2key_launch  - one line, absolute path to the right Fn action
+# The launch files are re-read on every press, so remapping in the editor takes
+# effect immediately with no restart. An unmapped key has no launch file and is
+# simply ignored.
+#
+# The action scripts are stateless togglers invoked with no argument (e.g.
+# com.trimui.toggle.ledc.sh flips the LED, com.trimui.switch.backlight.sh cycles
+# brightness), so this watchdog just executes the launch path as-is, exactly as
+# keymon did.
+#
+# Key codes: on the Brick the left/right Fn keys report as $B_L3 (1 317) and
+# $B_R3 (1 318) on $EVENT_PATH_READ_INPUTS_SPRUCE (event3). The Brick has no
+# analog sticks, so 317/318 are exclusively the Fn keys here (the B_L3/B_R3
+# naming is inherited from the shared TrimUI config). The node is read
+# non-exclusively, alongside the home/buttons watchdogs that already read it.
+
+. /mnt/SDCARD/spruce/scripts/helperFunctions.sh
+
+F1_LAUNCH="/usr/trimui/fnkeys/f1key_launch"
+F2_LAUNCH="/usr/trimui/fnkeys/f2key_launch"
+
+# Run the action named in a *key_launch file, if it points at a runnable script.
+# Backgrounded so a slow action never blocks the next keypress.
+run_fnkey() {
+    launch_file="$1"
+    which_key="$2"
+    [ -r "$launch_file" ] || return 0            # key unmapped: nothing to do
+    action=$(cat "$launch_file" 2>/dev/null)
+    [ -n "$action" ] || return 0                 # empty mapping
+    if [ ! -x "$action" ]; then
+        log_message "fnkey_watchdog.sh: $which_key Fn action not executable: $action"
+        return 0
+    fi
+    log_message "fnkey_watchdog.sh: $which_key Fn -> $action"
+    "$action" &
+}
+
+log_message "fnkey_watchdog.sh: Started up."
+
+# Outer loop restarts the reader if the getevent pipe ever exits, so the
+# watchdog stays durable like its siblings. -pid $$ makes getevent exit with us.
+while true; do
+    getevent -pid $$ "$EVENT_PATH_READ_INPUTS_SPRUCE" | while read line; do
+        case $line in
+            *"key $B_L3 1"*) run_fnkey "$F1_LAUNCH" left ;;
+            *"key $B_R3 1"*) run_fnkey "$F2_LAUNCH" right ;;
+        esac
+    done
+    log_message "fnkey_watchdog.sh: getevent pipe exited, restarting..."
+    sleep 1
+done

--- a/spruce/scripts/platform/device_functions/Brick.sh
+++ b/spruce/scripts/platform/device_functions/Brick.sh
@@ -37,3 +37,14 @@ device_init() {
         chmod +x /bin/bash
     fi
 }
+
+launch_startup_watchdogs() {
+    launch_common_startup_watchdogs_v2
+
+    # Dispatch the Brick's Fn keys (spruce does not run the stock keymon that
+    # would otherwise do this). Launched here so it lives alongside the other
+    # durable watchdogs and survives the early-boot churn; pinned like them.
+    /mnt/SDCARD/spruce/brick/fnkey_watchdog.sh &
+    SYSTEM_CPU=${DEVICE_MAX_CORES_ONLINE%"${DEVICE_MAX_CORES_ONLINE#?}"}
+    pin_cpu "$SYSTEM_CPU" -n fnkey_watchdog.sh &
+}

--- a/spruce/scripts/platform/device_functions/trimui_a133p.sh
+++ b/spruce/scripts/platform/device_functions/trimui_a133p.sh
@@ -192,6 +192,17 @@ device_init_a133p() {
     ) &
 }
 
+launch_startup_watchdogs() {
+    launch_common_startup_watchdogs_v2
+
+    # Dispatch the Brick's Fn keys (spruce does not run the stock keymon that
+    # would otherwise do this). Launched here so it lives alongside the other
+    # durable watchdogs and survives the early-boot churn; pinned like them.
+    /mnt/SDCARD/spruce/brick/fnkey_watchdog.sh &
+    SYSTEM_CPU=${DEVICE_MAX_CORES_ONLINE%"${DEVICE_MAX_CORES_ONLINE#?}"}
+    pin_cpu "$SYSTEM_CPU" -n fnkey_watchdog.sh &
+}
+
 set_event_arg_for_idlemon() {
     log_message "nothing to do" -v
 }

--- a/spruce/scripts/platform/device_functions/trimui_a133p.sh
+++ b/spruce/scripts/platform/device_functions/trimui_a133p.sh
@@ -192,17 +192,6 @@ device_init_a133p() {
     ) &
 }
 
-launch_startup_watchdogs() {
-    launch_common_startup_watchdogs_v2
-
-    # Dispatch the Brick's Fn keys (spruce does not run the stock keymon that
-    # would otherwise do this). Launched here so it lives alongside the other
-    # durable watchdogs and survives the early-boot churn; pinned like them.
-    /mnt/SDCARD/spruce/brick/fnkey_watchdog.sh &
-    SYSTEM_CPU=${DEVICE_MAX_CORES_ONLINE%"${DEVICE_MAX_CORES_ONLINE#?}"}
-    pin_cpu "$SYSTEM_CPU" -n fnkey_watchdog.sh &
-}
-
 set_event_arg_for_idlemon() {
     log_message "nothing to do" -v
 }


### PR DESCRIPTION
On the TrimUI Brick, the "Fn Key and Switch Settings" app lets you map an action to each of the two physical Fn keys, but pressing them did nothing. This adds Fn key support the spruce-native way: a small watchdog reads the Fn key presses and runs the mapped action, with no stock `keymon`.

This supersedes the earlier approach in #1548, which enabled Fn keys by adding the stock `keymon` daemon to the boot blob list. That PR was closed because spruce deliberately does not run `keymon` (it was removed across the project and replaced with spruce's own `getevent` watchdogs; `keymon` is kept only for the Miyoo Mini, where it is a different, stock component). This PR delivers the same feature using the existing watchdog pattern instead, so it fits that decision.

## Fn key watchdog

`spruce/brick/fnkey_watchdog.sh` reads Fn key-down events from `$EVENT_PATH_READ_INPUTS_SPRUCE` with `getevent` (the same idiom as `homebutton_watchdog.sh`) and runs the action the `fneditor` app mapped to each key. The chosen action is read fresh on every press from `/usr/trimui/fnkeys/f1key_launch` (left) and `f2key_launch` (right), so remapping in the editor takes effect immediately, and an unmapped key is ignored. The action scripts are stateless togglers invoked with no argument, so the watchdog just executes the launch path, exactly as `keymon` did.

On the Brick the left/right Fn keys report as `$B_L3` (`1 317`) and `$B_R3` (`1 318`) on `event3`; the Brick has no analog sticks, so those codes are exclusively the Fn keys. The node is read non-exclusively, alongside the home and buttons watchdogs that already read it, so there is no double-handling.

## Boot wiring

`launch_startup_watchdogs` in `trimui_a133p.sh` launches and CPU-pins the watchdog next to the common startup watchdogs, matching how the other durable watchdogs are started. The boot blob list is unchanged (no `keymon`).

## Validation

Tested on a physical Brick (FW 1.1.1) from a clean reboot: `keymon` is not running, `fnkey_watchdog.sh` starts and is pinned, and it coexists with the home, buttons, power, and volume watchdogs on the shared `event3` node. The right Fn key (mapped to the LCD brightness cycle) works end to end through spruce's own backlight control. The left Fn key's LED toggle dispatches correctly, but the stock LED action script is a no-op under spruce (it writes `/tmp/system/enable_led`, which the stock firmware daemons consume and spruce does not); making the physical RGB respond is a separate, pre-existing gap in that action script and is left for a follow-up.

Closes #1440
