### PR TITLE
Fix alternative folder names breaking scraper, favorites/recents, gamelist

### DIFF
--- a/App/MiyooGamelist/generate.py
+++ b/App/MiyooGamelist/generate.py
@@ -216,18 +216,22 @@ class GamelistGenerator:
                 self._log(f"SKIP {system_name}: no extlist found")
                 continue
 
-            rom_path = os.path.join(self.roms_dir, system_name)
-            if not os.path.isdir(rom_path):
+            # A system's ROMs may live under the canonical folder name or any of
+            # its alternativeFolderNames; generate a gamelist for each that exists.
+            rom_dirs = self._get_rom_dirs(system_name)
+            if not rom_dirs:
                 self._log(f"SKIP {system_name}: no ROM directory")
                 continue
 
-            self.messenger.display_image_and_text(
-                self.image_path,
-                f"Generating miyoogamelist.xml for {system_name}...",
-            )
-            rom_count = self._generate_for_system(system_name, rom_path, extlist)
-            self._log(f"OK   {system_name}: {rom_count} ROMs")
-            generated += 1
+            for rom_path in rom_dirs:
+                folder = os.path.basename(rom_path)
+                self.messenger.display_image_and_text(
+                    self.image_path,
+                    f"Generating miyoogamelist.xml for {folder}...",
+                )
+                rom_count = self._generate_for_system(system_name, rom_path, extlist)
+                self._log(f"OK   {system_name} ({folder}): {rom_count} ROMs")
+                generated += 1
 
         self._log("=" * 40)
         self._log(f"Done. Generated gamelists for {generated} systems.")
@@ -280,6 +284,27 @@ class GamelistGenerator:
             return {ext for ext in raw.split("|") if ext}
         except (FileNotFoundError, json.JSONDecodeError, KeyError):
             return None
+
+    def _get_rom_dirs(self, system_name: str) -> list:
+        """Return every existing ROM directory for a system: the canonical
+        Roms/{system} folder plus any alternativeFolderNames from config.json."""
+        folder_names = [system_name]
+        config_path = os.path.join(self.emu_dir, system_name, "config.json")
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            for alt in data.get("alternativeFolderNames", []) or []:
+                if alt and alt not in folder_names:
+                    folder_names.append(alt)
+        except (FileNotFoundError, json.JSONDecodeError, KeyError):
+            pass
+
+        rom_dirs = []
+        for folder in folder_names:
+            candidate = os.path.join(self.roms_dir, folder)
+            if os.path.isdir(candidate):
+                rom_dirs.append(candidate)
+        return rom_dirs
 
     # ---- per-system generation ---------------------------------------------
 

--- a/App/PyUI/main-ui/games/utils/game_system.py
+++ b/App/PyUI/main-ui/games/utils/game_system.py
@@ -12,6 +12,13 @@ class GameSystem:
         return os.path.basename(self._folder_paths[0])
 
     @property
+    def system_name(self):
+        # Canonical system name (the Emu/ folder name used to load config.json).
+        # Unlike folder_name, this is stable even when the ROM folder uses an
+        # alternativeFolderName, so it's the correct key for storage/lookup.
+        return self._game_system_config.system_name
+
+    @property
     def folder_paths(self):
         return self._folder_paths
     

--- a/App/PyUI/main-ui/menus/games/game_select_menu_popup.py
+++ b/App/PyUI/main-ui/menus/games/game_select_menu_popup.py
@@ -84,7 +84,7 @@ class GameSelectMenuPopup:
             )
             rom_image_list.append((name_without_ext, img_path))
             
-            BoxArtScraper().download_boxart_batch(rom_info.game_system.folder_name, rom_image_list)
+            BoxArtScraper().download_boxart_batch(rom_info.game_system.system_name, rom_image_list)
 
     def find_index_for_boxart(self, boxart_name, boxart_list):
         name_lower = boxart_name.lower()
@@ -117,7 +117,7 @@ class GameSelectMenuPopup:
             if(not scraper.check_wifi()):
                 return
 
-            image_list = scraper.get_image_list_for_system(rom_info.game_system.folder_name)
+            image_list = scraper.get_image_list_for_system(rom_info.game_system.system_name)
             if(image_list is not None):
                 name_without_ext = RomFileNameUtils.get_rom_name_without_extensions(
                     rom_info.game_system,
@@ -140,7 +140,7 @@ class GameSelectMenuPopup:
                         .replace("{boxart}", box_art)
                         .replace("{path}", img_path)
                     )
-                    scraper.download_remote_image_for_system(rom_info.game_system.folder_name, box_art,img_path)
+                    scraper.download_remote_image_for_system(rom_info.game_system.system_name, box_art,img_path)
                     BoxArtResizer.patch_boxart_list([img_path])
 
     def get_game_options(self, rom_info : RomInfo, additional_popup_options = [], rom_list= [], use_full_text = True):

--- a/App/PyUI/main-ui/menus/games/game_system_select_menu_popup.py
+++ b/App/PyUI/main-ui/menus/games/game_system_select_menu_popup.py
@@ -72,7 +72,7 @@ class GameSystemSelectMenuPopup:
                 )
                 rom_image_list.append((name_without_ext, img_path))
             
-            BoxArtScraper().download_boxart_batch(game_system.folder_name, rom_image_list)
+            BoxArtScraper().download_boxart_batch(game_system.system_name, rom_image_list)
 
     def run_popup_menu_selection(self, game_system : GameSystem):
         popup_options = []

--- a/App/PyUI/main-ui/menus/games/utils/collections_manager.py
+++ b/App/PyUI/main-ui/menus/games/utils/collections_manager.py
@@ -37,7 +37,7 @@ class CollectionsManager:
     @classmethod
     def convert_to_rom_list_entry(cls, rom_info):
         cls._wait_for_init()
-        return RomsListEntry(rom_info.rom_file_path, rom_info.game_system.folder_name)
+        return RomsListEntry(rom_info.rom_file_path, rom_info.game_system.system_name)
 
     @classmethod
     def load_entries_as_rom_info(cls, game_list) -> List['RomInfo']:

--- a/App/PyUI/main-ui/menus/games/utils/roms_list_manager.py
+++ b/App/PyUI/main-ui/menus/games/utils/roms_list_manager.py
@@ -43,12 +43,12 @@ class RomsListManager:
         return (str(Path(rom_file_path).resolve()), game_system_name)
 
     def add_game(self, rom_info: RomInfo):
-        key = self._entry_key(rom_info.rom_file_path, rom_info.game_system.folder_name)
+        key = self._entry_key(rom_info.rom_file_path, rom_info.game_system.system_name)
 
         if key in self._entries_dict:
             self.remove_game(rom_info)
 
-        new_entry = RomsListEntry(rom_info.rom_file_path, rom_info.game_system.folder_name, rom_info.display_name)
+        new_entry = RomsListEntry(rom_info.rom_file_path, rom_info.game_system.system_name, rom_info.display_name)
         self._entries.insert(0, new_entry)
         self._entries_dict[key] = new_entry
 
@@ -56,7 +56,7 @@ class RomsListManager:
         self.rom_info_list = self.load_entries_as_rom_info()
 
     def remove_game(self, rom_info: RomInfo):
-        key = self._entry_key(rom_info.rom_file_path, rom_info.game_system.folder_name)
+        key = self._entry_key(rom_info.rom_file_path, rom_info.game_system.system_name)
         entry = self._entries_dict.pop(key, None)
         if entry:
             self._entries = [e for e in self._entries if self._entry_key(e.rom_file_path, e.game_system_name) != key]
@@ -110,7 +110,7 @@ class RomsListManager:
         return self.rom_info_list
 
     def is_on_list(self, rom_info: RomInfo) -> bool:
-        key = self._entry_key(rom_info.rom_file_path, rom_info.game_system.folder_name)
+        key = self._entry_key(rom_info.rom_file_path, rom_info.game_system.system_name)
         return key in self._entries_dict
 
     def load_entries_as_rom_info(self) -> List[RomInfo]:

--- a/App/PyUI/main-ui/utils/boxart/box_art_scraper.py
+++ b/App/PyUI/main-ui/utils/boxart/box_art_scraper.py
@@ -84,6 +84,7 @@ class BoxArtScraper:
         self.preferred_region = Device.get_device().get_system_config().get_preferred_region()
         self._cache = {}  # sys_name -> list of (filename, token_set)
         self._arcade_xml_cache = None  # Single global dict: rom_name -> display_name for all arcade systems
+        self._folder_to_system = None  # Lazy map: on-disk ROM folder name -> canonical system name
     # ==========================================================
     # Helper Methods
     # ==========================================================
@@ -187,6 +188,18 @@ class BoxArtScraper:
             "ZXS": "Sinclair - ZX Spectrum",
         }
         return mapping.get(system.upper(), "")
+
+    def _resolve_canonical_system_name(self, folder_name: str) -> str:
+        """Map an on-disk ROM folder name (which may be an alternativeFolderName)
+        to its canonical system name. All alias/extension/list lookups are keyed
+        by the canonical name, so alternative folders must be resolved first.
+        Falls back to the folder name itself if no active system claims it."""
+        if self._folder_to_system is None:
+            self._folder_to_system = {}
+            for system in self.game_system_utils.get_active_systems():
+                for path in system.folder_paths:
+                    self._folder_to_system[os.path.basename(path)] = system.system_name
+        return self._folder_to_system.get(folder_name, folder_name)
 
     def _get_supported_extensions(self, sys_name: str) -> list[str]:
         """Get extensions from Emu config.json."""
@@ -674,7 +687,9 @@ class BoxArtScraper:
         tasks = []
 
         sys_path = os.path.join(self.roms_dir, sys_dir)
-        sys_name = os.path.basename(sys_path)
+        # sys_dir may be an alternativeFolderName; resolve to the canonical
+        # system name that the alias/extension/list lookups are keyed by.
+        sys_name = self._resolve_canonical_system_name(os.path.basename(sys_path))
 
         # Central Imgs folder at system level
         sys_imgs_dir = os.path.join(sys_path, Device.get_device().get_game_images_folder_name())


### PR DESCRIPTION
## Problem

ROM folders can be renamed via `alternativeFolderNames` in `Emu/<System>/config.json`, but several tools keyed off the on-disk folder name instead of the **canonical system name** (the `Emu/` folder name used to load `config.json`), breaking them for renamed folders:

- **#1576** — Box art scraper fails (relies on original folder names to know which system to scrape)
- **#1577** — Favourites and Recents break
- **#1579** — Gamelist cleanup tool deletes `miyoogamelist.xml` and never regenerates it

## Root cause

`GameSystem.folder_name` returns the first existing ROM folder's basename — the alternative name when a folder is renamed — while every lookup that needs config expects the canonical name. The `GameSystem` already holds the canonical name via its config; it was just never exposed or used.

Note: this only bites when the canonical folder is absent (i.e. the user renamed it away). Default installs ship the standard `Roms/` structure, so `folder_name == system_name` and behavior is unchanged there.

## Changes

- **`GameSystem`**: add a `system_name` property returning the canonical name from its config.
- **Favorites / Recents / GameSwitcher** (`roms_list_manager`) and **Collections** (`collections_manager`): store and look up entries by `system_name` so they survive renamed folders. No migration needed for the common case where `folder_name == system_name`. (#1577)
- **Box art scraper**: resolve on-disk folder names (which may be alternatives) to the canonical system name before alias/extension/list lookups; pass `system_name` from the single-game and per-system popup scrape paths. (#1576)
- **MiyooGamelist generate**: generate a gamelist for the canonical folder *and* every existing `alternativeFolderName`, so the cleanup pass no longer deletes gamelists that never get regenerated. (#1579)

## Note for review

On the muOS frontend port, `system_name` differs from `folder_name` for assign-based systems, so existing muOS favorites/recents/collections markers may reset once on upgrade (going forward they're consistent, since muOS already keys active systems by `system_name`). Native spruce devices are unaffected. Flagging since you own PyUI — happy to guard muOS explicitly if you'd prefer.

Fixes #1576, #1577, #1579