### PR TITLE
fix miyoo mini clean shutdown

### DIFF
--- a/spruce/scripts/platform/device_functions/MiyooMini.sh
+++ b/spruce/scripts/platform/device_functions/MiyooMini.sh
@@ -379,5 +379,5 @@ run_poweroff_cmd() {
 device_system_handles_sdcard_unmount() {
     # return 0 = true
     # return non-zero = false
-    return 0
+    return 1
 }

--- a/spruce/scripts/save_poweroff_stage2.sh
+++ b/spruce/scripts/save_poweroff_stage2.sh
@@ -9,6 +9,11 @@ export PATH=/usr/bin:/usr/sbin:/bin:/sbin
 unset LD_LIBRARY_PATH
 echo 2
 cd /tmp
+
+# Detach stage2 from inherited stdin/stdout/stderr so it does not
+# keep the SD filesystem busy during the final remount.
+exec </dev/null >/dev/null 2>&1
+
 echo 3
 # Close any file descriptors inherited from save_poweroff.sh that may
 # still reference files on the SD card.


### PR DESCRIPTION
i found that the sd card on my miyoo mini plus was still marked dirty after a normal shutdown.

i have very little experience with this kind of low-level linux/shutdown stuff, so i worked through it with a lot of ai help. this is the smallest solution i ended up with after testing.

i tested my fix on a miyoo mini plus:

"power off" from settings
mm+ power button from the main ui
mm+ power button while in a gba game
mm+ power button while in theme garden
reboot, then later power off

after each test, windows reported the sd card as:

PS D:\workbench> fsutil dirty query I:
Volume - I: is NOT Dirty

the changes are basically:

make miyoo mini use spruce's explicit sd unmount path
detach stage2 from inherited stdin/stdout/stderr before remounting/unmounting the card

i'm not very confident reviewing this kind of code myself, so please treat this more as a tested proposed fix than something i fully understand.

<3