### PR TITLE
change miyoo screenshot shortcut to menu+select

### DIFF
--- a/App/PyUI/main-ui/controller/controller.py
+++ b/App/PyUI/main-ui/controller/controller.py
@@ -1,3 +1,4 @@
+import os
 import time
 from controller.controller_inputs import ControllerInput
 from devices.device import Device
@@ -266,7 +267,16 @@ class Controller:
                             Controller.home_button_pressed()
                         Controller.clear_last_input()
                     elif Controller.last_controller_input == ControllerInput.MENU:
-                        if not Controller.is_check_for_hotkey and not called_from_check_for_hotkey and not Controller.check_for_hotkey():
+                        if not called_from_check_for_hotkey and os.path.exists("/tmp/screenshot_menu_consumed"):
+                            if not Controller.still_held_down():
+                                try:
+                                    os.remove("/tmp/screenshot_menu_consumed")
+                                except FileNotFoundError:
+                                    pass
+                            Controller.clear_last_input()
+                            was_hotkey = True
+                            break
+                        elif not Controller.is_check_for_hotkey and not called_from_check_for_hotkey and not Controller.check_for_hotkey():
                             Controller.set_last_input(ControllerInput.MENU)
                             break  # Treat MENU as valid input
                         else:
@@ -294,7 +304,10 @@ class Controller:
 
         if Controller.still_held_down():
             if(ControllerInput.MENU == Controller.last_input()):
-                was_hotkey = called_from_check_for_hotkey or Controller.check_for_hotkey()
+                if not called_from_check_for_hotkey and os.path.exists("/tmp/screenshot_menu_consumed"):
+                    was_hotkey = True
+                else:
+                    was_hotkey = called_from_check_for_hotkey or Controller.check_for_hotkey()
                 if(not was_hotkey and not Controller.gs_triggered and Controller.allow_pyui_game_switcher()):
                     Controller.gs_triggered = True
                     Controller.first_check_after_gs_triggered = True

--- a/Saves/spruce/spruce-config.json
+++ b/Saves/spruce/spruce-config.json
@@ -256,7 +256,8 @@
                     "Off",
                     "L2+R2+Y",
                     "L2+R2+X",
-                    "L2+R2+DOWN"
+                    "L2+R2+DOWN",
+                    "MENU+SELECT"
                 ],
                 "selected": "L2+R2+Y"
             },

--- a/spruce/scripts/buttons_watchdog.sh
+++ b/spruce/scripts/buttons_watchdog.sh
@@ -123,6 +123,11 @@ case "$SS_SHORTCUT" in
     "L2+R2+DOWN")
         SS_B3=$B_DOWN
         ;;
+    "MENU+SELECT")
+        SS_B1=$B_MENU
+        SS_B2=$B_SELECT
+        SS_B3="NULL"
+        ;;
     "Off")
         SS_B1="NULL"
         SS_B2="NULL"
@@ -133,6 +138,32 @@ esac
 SS_B1_DOWN=false
 SS_B2_DOWN=false
 SS_B3_DOWN=false
+
+SCREENSHOT_MENU_CONSUMED="/tmp/screenshot_menu_consumed"
+SS_MENU_CONSUME_ID=0
+rm -f "$SCREENSHOT_MENU_CONSUMED"
+
+mark_screenshot_menu_consumed() {
+    [ "$SS_SHORTCUT" = "MENU+SELECT" ] || return
+
+    SS_MENU_CONSUME_ID=$((SS_MENU_CONSUME_ID + 1))
+    printf '%s\n' "$$-$SS_MENU_CONSUME_ID" > "$SCREENSHOT_MENU_CONSUMED"
+}
+
+schedule_screenshot_menu_cleanup() {
+    [ "$SS_SHORTCUT" = "MENU+SELECT" ] || return
+    [ "$SS_B1_DOWN" = false ] || return
+    [ "$SS_B2_DOWN" = false ] || return
+    [ -e "$SCREENSHOT_MENU_CONSUMED" ] || return
+
+    SS_MENU_CONSUME_TOKEN="$(cat "$SCREENSHOT_MENU_CONSUMED" 2>/dev/null)"
+    (
+        sleep 1
+        if [ "$(cat "$SCREENSHOT_MENU_CONSUMED" 2>/dev/null)" = "$SS_MENU_CONSUME_TOKEN" ]; then
+            rm -f "$SCREENSHOT_MENU_CONSUMED"
+        fi
+    ) &
+}
 
 # scan all button input
 EVENTS="$EVENT_PATH_READ_INPUTS_SPRUCE"
@@ -159,21 +190,25 @@ getevent $EVENTS | while read line; do
         ;;
         *"key $SS_B1 1"*) # Screenshot key 1 down
             SS_B1_DOWN=true
-            if [ "$SS_B2_DOWN" = true ] && [ "$SS_B3_DOWN" = true ] ; then
+            if [ "$SS_B2_DOWN" = true ] && { [ "$SS_B3" = "NULL" ] || [ "$SS_B3_DOWN" = true ]; }; then
+                mark_screenshot_menu_consumed
                 take_screenshot_bg &
             fi
         ;;
         *"key $SS_B1 0"*) # Screenshot key 1 up
             SS_B1_DOWN=false
+            schedule_screenshot_menu_cleanup
         ;;
         *"key $SS_B2 1"*) # Screenshot key 2 down
             SS_B2_DOWN=true
-            if [ "$SS_B1_DOWN" = true ] && [ "$SS_B3_DOWN" = true ] ; then
+            if [ "$SS_B1_DOWN" = true ] && { [ "$SS_B3" = "NULL" ] || [ "$SS_B3_DOWN" = true ]; }; then
+                mark_screenshot_menu_consumed
                 take_screenshot_bg &
             fi
         ;;
         *"key $SS_B2 0"*) # Screenshot key 2 up
             SS_B2_DOWN=false
+            schedule_screenshot_menu_cleanup
         ;;
         *"key $SS_B3 1"*) # Screenshot key 3 down
             SS_B3_DOWN=true

--- a/spruce/scripts/homebutton_watchdog.sh
+++ b/spruce/scripts/homebutton_watchdog.sh
@@ -10,6 +10,9 @@ log_message "homebutton_watchdog.sh: Started up."
 
 RETROARCH_CFG="/mnt/SDCARD/RetroArch/retroarch.cfg"
 
+SCREENSHOT_SHORTCUT="$(get_config_value '.menuOptions."System Settings".globalScreenshotShortcut.selected' "L2+R2+Y")"
+SELECT_DOWN=false
+
 cancel_menu_hold() {
     # If the menu button is currently held, cancel both tap and hold
     if [ -e /tmp/menubtn ]; then
@@ -100,7 +103,9 @@ getevent -pid $$ $EVENT_PATH_READ_INPUTS_SPRUCE | while read line; do
     case $line in
         # Home key down
         *"key $B_MENU 1"*)
-                home_key_down
+                if [ "$SCREENSHOT_SHORTCUT" != "MENU+SELECT" ] || [ "$SELECT_DOWN" = false ]; then
+                    home_key_down
+                fi
             ;;
 
         # Home key up
@@ -108,8 +113,17 @@ getevent -pid $$ $EVENT_PATH_READ_INPUTS_SPRUCE | while read line; do
                 home_key_up
             ;;
 
+        *"key $B_SELECT 1"*)
+            SELECT_DOWN=true
+            cancel_menu_hold
+            resume_drastic
+            ;;
+
+        *"key $B_SELECT 0"*)
+            SELECT_DOWN=false
+            ;;
+
         *"key $B_START 1"*  | \
-        *"key $B_SELECT 1"* | \
         *"key $B_R1"*      | \
         *"key $B_R2"*      | \
         *"key $B_L1"*      | \

--- a/spruce/scripts/platform/MiyooMini.cfg
+++ b/spruce/scripts/platform/MiyooMini.cfg
@@ -97,7 +97,7 @@ export B_R3="B_R3" # used to send virtual keypresses to emulators
 
 export B_START="B_START"
 export B_START_2="enter_pressed" # only registers 0 on release, no 1 on press
-export B_SELECT="B_SELECT"
+export B_SELECT="B_SEL"
 export B_SELECT_2="rctrl_pressed"
 
 export B_VOLUP="B_VOLUP"


### PR DESCRIPTION
adds MENU+SELECT as an additional global screenshot shortcut option.

changes:
- add MENU+SELECT to the existing global screenshot shortcut setting
- fix Miyoo Mini select button mapping so B_SELECT matches the actual B_SEL input event

tested on Miyoo Mini Plus:
- screenshot from spruce ui
- screenshot in-game