### PR TITLE
Wifi switch

### DIFF
--- a/App/PyUI/main-ui/devices/trimui/trim_ui_device.py
+++ b/App/PyUI/main-ui/devices/trimui/trim_ui_device.py
@@ -32,10 +32,22 @@ class TrimUIDevice(DeviceCommon):
 
     def on_system_config_changed(self):
         old_volume = self.system_config.get_volume()
+        old_wifi_enabled = self.system_config.is_wifi_enabled()
         self.system_config.reload_config()
         new_volume = self.system_config.get_volume()
         if(old_volume != new_volume):
             Display.volume_changed(new_volume)
+
+        # Something outside this process - the physical switch's
+        # scene-wifi.sh, today - can flip .wifi in this same file while PyUI
+        # is already running. reload_config() above already picks up the
+        # fresh value, so monitor_wifi()'s self-heal loop won't fight the
+        # switch by turning WiFi back on - but the WiFi status caches still
+        # need an explicit nudge so the WiFi menu/top bar icon catch up
+        # immediately instead of waiting on their own throttle window.
+        if(old_wifi_enabled != self.system_config.is_wifi_enabled()):
+            self.get_wifi_status.force_refresh()
+            self.get_ip_addr_text.force_refresh()
 
     def ensure_wpa_supplicant_conf(self):
         MiyooTrimCommon.ensure_wpa_supplicant_conf(self.get_wpa_supplicant_conf_path())

--- a/App/PyUI/main-ui/devices/trimui/trim_ui_smart_pro_s.py
+++ b/App/PyUI/main-ui/devices/trimui/trim_ui_smart_pro_s.py
@@ -154,6 +154,23 @@ class TrimUISmartProS(TrimUIDevice):
             if(old_volume != self.mainui_volume):
                 Display.volume_changed(self.mainui_volume * 5)
 
+            # Something outside this process - the physical switch's
+            # scene-wifi.sh, today - can flip .wifi in this same file while
+            # PyUI is already running. self.system_config only reflects what
+            # PyUI itself last wrote, so without this, monitor_wifi()'s
+            # self-heal loop keeps believing WiFi should still be in whatever
+            # state it was in at startup: it sees wlan0 go down, doesn't know
+            # the radio was turned off on purpose, and switches it back on
+            # within one poll (up to ~10s). Reloading here - this callback
+            # already runs on every change to this file - keeps
+            # is_wifi_enabled() and the status caches honest with whatever
+            # last touched it, switch or otherwise.
+            old_wifi_enabled = self.system_config.is_wifi_enabled()
+            self.system_config.reload_config()
+            if old_wifi_enabled != self.system_config.is_wifi_enabled():
+                self.get_wifi_status.force_refresh()
+                self.get_ip_addr_text.force_refresh()
+
         except Exception as e:
             PyUiLogger.get_logger().warning(f"Error reading {path}: {e}")
             return None

--- a/Saves/spruce/spruce-config.json
+++ b/Saves/spruce/spruce-config.json
@@ -335,6 +335,7 @@
                     "LED off",
                     "Quiet Mode",
                     "Silent Mode",
+                    "WiFi off",
                     "Nothing"
                 ],
                 "changeCmd": "/mnt/SDCARD/spruce/smartpros/bin/apply-switch-action",

--- a/spruce/smartpros/bin/apply-switch-action
+++ b/spruce/smartpros/bin/apply-switch-action
@@ -28,18 +28,21 @@ SELF_DIR="/mnt/SDCARD/spruce/smartpros/bin"
 apply_now() {
     action="$(get_config_value '.menuOptions."Button Settings".switchAction.selected' "Nothing")"
 
-    # Map the menu label to the spruce-native action script to install. All three
+    # Map the menu label to the spruce-native action script to install. All four
     # actions drive spruce's own systems rather than the stock scene scripts,
     # whose control numbering is wrong on this device: the stock quiet script
     # pokes tinymix control 9 (DACL DACR Swap, not volume) and the stock ledc.sh
     # derives brightness from a shmvar spruce never populates. scene-rgb-led.sh
     # drives the LEDs via rgb_led; scene-quiet.sh / scene-silent.sh go through
-    # set_volume so the audio and the in-UI volume reading stay in sync.
+    # set_volume so the audio and the in-UI volume reading stay in sync;
+    # scene-wifi.sh goes through enable_wifi / disable_wifi so the radio and
+    # .wifi in SYSTEM_JSON stay in sync the same way.
     src=""; name=""
     case "$action" in
         "LED off")     src="$SELF_DIR/scene-rgb-led.sh"; name="scene-rgb-led.sh" ;;
         "Quiet Mode")  src="$SELF_DIR/scene-quiet.sh";   name="scene-quiet.sh" ;;
         "Silent Mode") src="$SELF_DIR/scene-silent.sh";  name="scene-silent.sh" ;;
+        "WiFi off")    src="$SELF_DIR/scene-wifi.sh";    name="scene-wifi.sh" ;;
         "Nothing"|*)   src=""; name="" ;;
     esac
 

--- a/spruce/smartpros/bin/scene-wifi.sh
+++ b/spruce/smartpros/bin/scene-wifi.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Switch scene action: turn WiFi on/off through spruce's own WiFi system.
+#
+# trimui_scened runs this with arg 1 (switch on -> WiFi off) / 0 (switch off ->
+# WiFi back on). Goes through the same enable_wifi / disable_wifi that boot,
+# sleep, and Settings -> Network Settings -> WiFi already use, and keeps .wifi
+# in SYSTEM_JSON in sync (the same pattern set_backlight uses for .backlight)
+# so the WiFi menu, the top bar icon, and anything else that reads .wifi (e.g.
+# handle_network_services) agree with the state the switch put the radio in.
+#
+# Unlike the Brick (whose switch draws its own on-screen toast), the Smart Pro S
+# switch has no popup, so the WiFi menu / top bar icon is the only feedback the
+# user gets that the switch did something.
+
+. /mnt/SDCARD/spruce/scripts/helperFunctions.sh
+
+set_wifi_config_value() {
+    tmp="$(mktemp)"
+    jq ".wifi = $1" "$SYSTEM_JSON" > "$tmp" && mv "$tmp" "$SYSTEM_JSON"
+}
+
+case "$1" in
+    1)
+        set_wifi_config_value 0
+        disable_wifi
+        ;;
+    0)
+        set_wifi_config_value 1
+        enable_wifi
+        ;;
+esac


### PR DESCRIPTION
Make the physical switch on the trimui smart pro s function like wifi switch on a real PSP!

Questions:
1. What about the TrimUI Smart Pro? I should probably mirror these changes to `App/PyUI/main-ui/devices/trimui/trim_ui_smart_pro.py`, yeah?
2. Is this going to cause trouble for any other platforms? Does spruce support any hardware that _has_ a switch but _does not have_ wifi?