### PR TITLE
Fix five regressions from the automated batch (#1633), and two bugs it surfaced

### DIFF
--- a/App/Moonlight/launch.sh
+++ b/App/Moonlight/launch.sh
@@ -18,16 +18,24 @@ chmod +x ./moonlight/moonlight
 ./love gui
 
 cd "$MOONDIR"
-COMMAND=$(cat command.txt)
-
 export GAMEDIR
-/mnt/SDCARD/spruce/bin64/gptokeyb "moonlight" &
-set -f
-# shellcheck disable=SC2086
-set -- $COMMAND
-set +f
-./moonlight "$@"
-kill -9 $(pidof gptokeyb) 2>/dev/null
+
+# No command.txt means the GUI was closed without picking an app.
+#
+# It is written by gui/main.lua, one argument per line. Read it that way:
+# word-splitting it would neither strip quotes nor expand anything, so an app
+# name with spaces would arrive as several arguments. "stream" and -keydir go
+# on here because this is the script that knows GAMEDIR.
+if [ -f command.txt ]; then
+    set -- stream -keydir "$GAMEDIR/keys"
+    while IFS= read -r moonlight_arg || [ -n "$moonlight_arg" ]; do
+        [ -n "$moonlight_arg" ] && set -- "$@" "$moonlight_arg"
+    done < command.txt
+
+    /mnt/SDCARD/spruce/bin64/gptokeyb "moonlight" &
+    ./moonlight "$@"
+    kill -9 $(pidof gptokeyb) 2>/dev/null
+fi
 
 rm -f command.txt
 rm -f /tmp/stay_awake

--- a/App/Moonlight/ports/moonlightnew/gui/main.lua
+++ b/App/Moonlight/ports/moonlightnew/gui/main.lua
@@ -1323,6 +1323,14 @@ end
 function writeSelectedApp(selectedApp, bitrate, resolution, framerate, codec, remote)
     -- Split resolution string into width and height
     local width, height = resolution:match("(%d+)x(%d+)")
+    if not width or not height then
+        -- A nil here used to blow up on the .. concatenation below. It must
+        -- not reach the args table instead: a nil in a table constructor is
+        -- dropped rather than stored, so table.concat would quietly write a
+        -- truncated argument list and moonlight would fail for no clear reason.
+        print("Error: Could not parse resolution " .. tostring(resolution))
+        return
+    end
     
     -- Read IP address from ip.txt
     local ipFile = io.open(ipFilePath, "r")  -- Adjusted IP file path
@@ -1336,16 +1344,40 @@ function writeSelectedApp(selectedApp, bitrate, resolution, framerate, codec, re
     end
     
     
-    -- Construct the command string with app name, bitrate, resolution, framerate, codec, remote, and IP address
-    local command = 'stream -platform sdl -app "' .. selectedApp .. '" ' ..
-                    '-keydir "$GAMEDIR/keys" ' ..
-                    '-bitrate ' .. bitrate .. ' ' ..
-                    '-width ' .. width .. ' ' ..
-                    '-height ' .. height .. ' ' ..
-                    '-fps ' .. framerate .. ' ' ..
-                    '-codec ' .. codec .. ' ' ..
-                    '-remote ' .. remote .. ' ' ..
-                    '-quitappafter ' .. ipAddress
+    -- ip.txt is read with "*all", so it carries whatever trailing newline the
+    -- writer left. That has to go before the value becomes an argument.
+    ipAddress = ipAddress:gsub("%s+$", "")
+
+    -- One argument per line. launch.sh reads this back with
+    -- `while IFS= read -r`, so an app name with spaces ("Steam Big Picture")
+    -- arrives as a single argument and nothing here is expanded by a shell.
+    -- The old form wrote shell syntax - embedded quotes and a literal
+    -- $GAMEDIR - which only worked because launch.sh ran it through eval.
+    --
+    -- "stream" and -keydir are prepended by launch.sh: it is what knows
+    -- GAMEDIR, and this file has no way to resolve it.
+    -- Same reasoning as the resolution guard: any nil here would be dropped by
+    -- the table constructor rather than stored, silently truncating the
+    -- argument list. The old .. concatenation raised on nil; keep it loud.
+    if not selectedApp or not bitrate or not framerate or not codec
+            or not remote or ipAddress == "" then
+        print("Error: incomplete stream settings; not writing command.txt")
+        return
+    end
+
+    local args = {
+        "-platform", "sdl",
+        "-app", selectedApp,
+        "-bitrate", bitrate,
+        "-width", width,
+        "-height", height,
+        "-fps", framerate,
+        "-codec", codec,
+        "-remote", remote,
+        "-quitappafter",
+        ipAddress,
+    }
+    local command = table.concat(args, "\n") .. "\n"
 
     local file = io.open("moonlight/command.txt", "w")
     if file then

--- a/App/PyUI/main-ui/menus/games/utils/rom_select_options_builder.py
+++ b/App/PyUI/main-ui/menus/games/utils/rom_select_options_builder.py
@@ -72,7 +72,12 @@ class RomSelectOptionsBuilder:
                 return save_state_image_path
 
 
-        if(game_entry is not None):
+        # A <game> in gamelist.xml with no <image> yields image=None, and
+        # CachedExists.exists(None) raises TypeError out of os.path.normpath.
+        # This is reached lazily while the ROM grid draws, outside any handler,
+        # so an unscraped entry takes the whole list down. "" is not safe
+        # either: normpath("") is ".", which exists.
+        if(game_entry is not None and game_entry.image):
             if(CachedExists.exists(game_entry.image)):
                 return game_entry.image
 
@@ -303,7 +308,10 @@ class RomSelectOptionsBuilder:
                 rom_file_name = os.path.basename(rom_file_path)
 
                 game_entry = get_by_file_path(rom_file_path)
-                display_name = game_entry.name if game_entry else get_name_no_ext(game_system, rom_file_path)
+                # A <game> with no <name> gives name=None, which reaches
+                # get_sort_key() -> .strip() and takes the whole list down.
+                # Fall back exactly as a missing entry already does.
+                display_name = game_entry.name if (game_entry and game_entry.name) else get_name_no_ext(game_system, rom_file_path)
 
                 if not filter(rom_file_name, rom_file_path, display_name):
                     continue
@@ -325,7 +333,7 @@ class RomSelectOptionsBuilder:
             for rom_file_path in valid_folders:
                 rom_file_name = os.path.basename(rom_file_path)
                 game_entry = get_by_file_path(rom_file_path)
-                display_name = game_entry.name if game_entry else rom_file_name
+                display_name = game_entry.name if (game_entry and game_entry.name) else rom_file_name
 
                 if not filter(rom_file_name, rom_file_path, display_name):
                     continue

--- a/App/RandomGame/random.sh
+++ b/App/RandomGame/random.sh
@@ -101,7 +101,13 @@ if [ -f "$BOX_ART_PATH" ]; then
     kill $(jobs -p)
 fi
 
-LAUNCH_SCRIPT="/mnt/SDCARD/spruce/scripts/emu/standard_launch.sh"
+# standard_launch.sh takes its identity from $0: it strips up to "/Emu/" and
+# keeps the next path component as EMU_NAME. So it has to be invoked through
+# Emu/<system>/, and the ../../ detour is load-bearing rather than redundant.
+# Calling the canonical path directly leaves EMU_NAME empty and the game
+# launches with no emulator. The same string goes to /tmp/cmd_to_run.sh, where
+# button_actions.sh greps Emu/<system>/ back out for the game switcher.
+LAUNCH_SCRIPT="/mnt/SDCARD/Emu/${FOLDER_NAME}/../../spruce/scripts/emu/standard_launch.sh"
 echo "\"$LAUNCH_SCRIPT\" \"${SELECTED_GAME}\"" > /tmp/cmd_to_run.sh
 "$LAUNCH_SCRIPT" "$SELECTED_GAME"
 

--- a/Emu/PS/config.json
+++ b/Emu/PS/config.json
@@ -4,7 +4,7 @@
   "iconsel": "ps_sel.png",
   "themecolor": "00FF00",
   "launch": "../../spruce/scripts/emu/standard_launch.sh",
-  "extlist": "m3u|chd|cue|img|mdf|pbp|toc|cbn|iso",
+  "extlist": "m3u|chd|cue|img|mdf|pbp|PBP|toc|cbn|iso",
   "launchlist": [
     {
       "name": "Generate M3U playlists for multi-disc games",

--- a/spruce/scripts/lid_watchdog_v2.sh
+++ b/spruce/scripts/lid_watchdog_v2.sh
@@ -15,7 +15,13 @@ fi
 
 log_message "Lid watchdog started, monitoring lid state"
 
-previous_state=1
+# Tracks whether THIS lid close has already been acted on, which is not the
+# same as the raw lid state. Latching the raw state meant a close that was
+# rejected (charging, under "Only when unplugged") still counted as handled:
+# unplugging later with the lid still shut could never sleep, because the
+# open->closed edge never came round again until the lid was physically
+# cycled. Cleared when the lid actually opens.
+close_handled=0
 
 launch_sleep_helper_once() {
     if [ -e /tmp/sleep_helper_started ]; then
@@ -37,14 +43,16 @@ while true; do
     case "$lid_sleep_enabled" in
         "True")
             # Detect lid close only
-            if [ "$current_state" = "0" ] && [ "$previous_state" = "1" ]; then
+            if [ "$current_state" = "0" ] && [ "$close_handled" = "0" ]; then
+                close_handled=1
                 launch_sleep_helper_once
                 current_state=$(device_lid_open)
             fi
             ;;
         "Only when unplugged")
             # Detect lid close and charging state
-            if [ "$current_state" = "0" ] && [ "$previous_state" = "1" ] && [ "$(device_get_charging_status)" = "Discharging" ]; then
+            if [ "$current_state" = "0" ] && [ "$close_handled" = "0" ] && [ "$(device_get_charging_status)" = "Discharging" ]; then
+                close_handled=1
                 launch_sleep_helper_once
                 current_state=$(device_lid_open)
             fi
@@ -55,6 +63,7 @@ while true; do
             ;;
     esac
 
-    previous_state="$current_state"
+    # An open lid arms the next close, whether or not this one was acted on.
+    [ "$current_state" = "1" ] && close_handled=0
     sleep 0.5
 done

--- a/spruce/scripts/platform/AnbernicXXCommon.cfg
+++ b/spruce/scripts/platform/AnbernicXXCommon.cfg
@@ -54,7 +54,13 @@ export CONSERVATIVE_POLICY_DIR="/tmp"
   ##################################################
 
 export BATTERY="/sys/class/power_supply/axp2202-battery"
-export LED_PATH=""
+# "not applicable" is the sentinel every LED-less platform uses, and it is not
+# cosmetic: LED_PATH is concatenated as ${LED_PATH}/brightness and
+# ${LED_PATH}/trigger, so an empty value resolves to /brightness and
+# /trigger and the writes land at the filesystem root. runtime.sh does it on
+# every boot, save_poweroff.sh on every shutdown, and low_power_warning.sh
+# every 30s. The guards all test against this exact string.
+export LED_PATH="not applicable"    # the XX line has no controllable LED
 export DEVICE_BRIGHTNESS_PATH=""
 # Not applicable: the XX line has no rumble GPIO. There is no /sys/class/motor,
 # no timed_output, no exported gpio and nothing named vibra/motor anywhere in


### PR DESCRIPTION
PR #1633 traded several working oddities for clean-looking breakage. Five of these are regressions from that batch; two are older bugs found while reviewing it.

The recurring theme: #1633 removed things that looked redundant but weren't — a path detour, an `eval`, an uppercase file extension.

## Regressions from #1633

### RandomGame launched every game with no emulator
`standard_launch.sh:22` takes its identity from `$0` — it strips up to `/Emu/` and keeps the next path component as `EMU_NAME`. The `Emu/<system>/../../` detour was load-bearing, not redundant. The canonical path contains no `/Emu/`, so `EMU_NAME` came out empty and `EMU_JSON_PATH` became `/mnt/SDCARD/Emu//config.json`.

Three consumers broke:
1. Core/emulator selection
2. The game switcher — `button_actions.sh` greps `Emu/<system>/` back out of `/tmp/cmd_to_run.sh`
3. **Auto-resume** — `save_poweroff.sh:180` (`close_non_emu_cmd_to_run`) greps for `/mnt/SDCARD/Emu` to tell an emulator from an App. Every random launch classified as an App, and that branch does `rm -f "${FLAGS_DIR}/lastgame.lock"`

The `eval` removal from that commit is kept.

### Every Moonlight stream failed
`gui/main.lua:1339` writes shell syntax — quoted arguments and a literal `$GAMEDIR` — which only worked because `launch.sh` ran it through `eval`. Replacing `eval` with `set -- $COMMAND` does neither quote removal nor parameter expansion, so moonlight received the literal `"Desktop"` *with* its quotes and the literal string `$GAMEDIR/keys`. Multi-word app names ("Steam Big Picture") split into several arguments.

Fixed at the producer: one argument per line, read back with `while IFS= read -r`. `launch.sh` contributes `stream` and `-keydir` because it's what knows `GAMEDIR`.

Two guards go with it — a `nil` in a Lua table constructor is *dropped* rather than stored, so `table.concat` would quietly write a truncated argument list where the old `..` raised.

### ROM lists crashed on any gamelist entry without `<image>`
`image=None` reaches `CachedExists.exists` → `os.path.normpath(None)` → `TypeError`, raised lazily while the grid draws and outside any handler. `""` is not a safe placeholder either: `normpath("")` is `"."`, which exists.

### `EBOOT.PBP` disappeared from PSX
PyUI lowercases both sides, so dropping the uppercase entry was a no-op there. But `MiyooGamelist/generate.py:374` and `RandomGame/random.sh:44` both match case-sensitively, and uppercase is the canonical form for these images.

### "Only when unplugged" could no longer sleep on unplug
The edge trigger latched the raw lid state even on the loop where the charging check rejected the close. Closing the lid while charging and unplugging later never slept until the lid was physically cycled. Now latches whether *this close* was acted on, separately from the lid state, cleared when the lid opens.

## Older bugs found while reviewing

### A `<game>` with `<path>` but no `<name>` takes down the ROM list sort
`name=None` becomes `display_name`, and `get_sort_key()` calls `.strip()` on it. `rom_select_options_builder.py:352-353` sorts every file and folder list that way. Falls back to the filename the way a missing entry already does.

### `AnbernicXXCommon.cfg` set `LED_PATH=""`
Every other LED-less platform uses the `"not applicable"` sentinel, and it isn't cosmetic: `LED_PATH` is concatenated, so an empty value resolves to `/brightness` and `/trigger` and the writes land at the filesystem root — on every boot from `runtime.sh:18`, every shutdown from `save_poweroff.sh:30`, and every 30s once `low_power_warning.sh` started running there.

## Testing

Verified by source reading and local execution (Lua, shell and Python all run on the dev machine):

- `EMU_NAME` resolves to the system again, and the game-switcher `sed` and the autoresume grep both classify correctly
- Moonlight end-to-end: real LuaJIT writes `command.txt`, the actual reader parses it — 21 arguments, multi-word app name intact as one, keydir expanded, IP trailing newline stripped
- Lid watchdog simulated against old and new logic across four timelines: old gives 0 sleeps in the close-while-charging-then-unplug case, new gives exactly 1 at the moment of unplug, with the no-repeat and re-arm properties intact
- All touched shell scripts pass `sh -n`, Python compiles, Lua loads, JSON parses
- Line endings preserved (`rom_select_options_builder.py` is CRLF)

**Not tested on hardware.** The Moonlight change touches both sides of a producer/consumer pair and deserves a real stream before merge.

## Not in this PR, but worth knowing

- `archiveUnpacker.sh` — the tightened member check is correct and should stay, but it's the first time that check has ever actually run (the old grep matched the listing header unconditionally, so it always passed). Expect "my theme stopped installing" reports.
- `button_actions.sh:322` — the new `wait` before `killall sendevent`. Couldn't verify the hang risk either way; `sendevent` ships as a binary with no source in-tree.
- The new language keys leave 149 untranslated strings per language. No existing translation was clobbered — checked all 28 files key by key.
