### PR TITLE
DSperate follow-ups: reach kill_dsperate, and stop guessing state paths

### DIFF
--- a/Emu/NDS/config.json
+++ b/Emu/NDS/config.json
@@ -89,7 +89,8 @@
         "Enabled",
         "Disabled"
       ],
-      "selected": "Enabled"
+      "selected": "Enabled",
+      "overrides": {}
     }
   },
   "sortOrder": 4000,

--- a/spruce/scripts/button_actions.sh
+++ b/spruce/scripts/button_actions.sh
@@ -159,7 +159,7 @@ kill_emulator() {
         kill_pcsx
     elif pgrep "gvu" >/dev/null; then
         kill_gvu
-    elif pgrep dsperate-sdl >/dev/null; then
+    elif pgrep dsperate >/dev/null; then
         kill_dsperate
     elif pgrep -f "bigpemu" >/dev/null; then
         kill_bigpemu

--- a/spruce/scripts/emu/lib/dsperate_functions.sh
+++ b/spruce/scripts/emu/lib/dsperate_functions.sh
@@ -57,8 +57,9 @@ is_autoload_enabled() {
 
 # The NDS header carries a four-character game code at offset 12, and DSperate
 # names the auto slot after it, so the launcher has to read it the same way to
-# know which file to resume from. 7zr cannot open a .rar and neither can
-# python's zipfile, so those come back empty rather than wrong.
+# know which file to resume from. Only the two containers DSperate itself
+# opens are handled: a .7z has already been unpacked by prepare_dsperate_rom
+# before this is called, and nothing on the card can read a .rar.
 get_game_code() {
 	case "$1" in
 	*.nds | *.NDS)
@@ -74,9 +75,6 @@ with zipfile.ZipFile(sys.argv[1]) as z:
             break
 " "$1" 2>/dev/null
 		;;
-	*.7z | *.7Z)
-		7zr e "$1" -so 2>/dev/null | dd bs=1 skip=12 count=4 2>/dev/null
-		;;
 	esac
 }
 
@@ -88,6 +86,55 @@ get_state_path() {
 	_code="$(get_game_code "$1" | tr -dc 'A-Za-z0-9#_-')"
 	[ -n "$_code" ] || return 0
 	echo "/mnt/SDCARD/Saves/states/dsperate/${_code}.auto.dss"
+}
+
+# DSperate reads .nds and .zip itself (the vendored miniz in core/cart/zip.cpp),
+# so .7z is the only container that needs unpacking. NDS extlist also offers
+# .rar, which nothing on the card can open - 7zr is a 7z-only build.
+#
+# Unpacked to the card, not to mktemp's /tmp: /tmp is tmpfs here, and an NDS
+# ROM is tens to hundreds of megabytes of RAM the emulator is about to want for
+# itself.
+#
+# The unpacked file keeps the archive's own name because DSperate derives the
+# battery save from the ROM's filename stem, not from the game code
+# (save_path() in its main.cpp). Extract every game to a fixed "rom.nds" and
+# they all share one .sav, which loses saves rather than just misplacing them.
+DSPERATE_TMP_DIR="/mnt/SDCARD/spruce/tmp/dsperate"
+
+prepare_dsperate_rom() {
+	case "$1" in
+	*.7z | *.7Z) ;;
+	*) echo "$1"; return 0 ;;
+	esac
+
+	# A previous launch killed with -9 leaves its unpacked ROM behind.
+	rm -rf "$DSPERATE_TMP_DIR"
+	mkdir -p "$DSPERATE_TMP_DIR"
+
+	_member="$(7zr l -slt "$1" 2>/dev/null | sed -n 's/^Path = //p' | grep -iE '\.nds$' | head -1)"
+	if [ -z "$_member" ]; then
+		log_message "DSperate: no .nds inside $(basename "$1")"
+		return 1
+	fi
+
+	# Uncompressed size against what the card has free, both in KB. NF-2 is the
+	# Available column counted from the right, so a wrapped df line still reads.
+	_need_kb=$(( $(7zr l -slt "$1" 2>/dev/null | sed -n 's/^Size = //p' | awk '{s+=$1} END {print s+0}') / 1024 + 1 ))
+	_free_kb="$(df -k "$DSPERATE_TMP_DIR" | awk 'END {print $(NF-2)}')"
+	if [ "$_free_kb" -lt $((_need_kb + 16384)) ]; then
+		log_message "DSperate: not enough card space to unpack $(basename "$1"): needs ${_need_kb}KB, ${_free_kb}KB free"
+		return 1
+	fi
+
+	_stem="$(basename "$1")"
+	_out="$DSPERATE_TMP_DIR/${_stem%.*}.nds"
+	if ! 7zr e "$1" "$_member" -so > "$_out"; then
+		log_message "DSperate: could not unpack $(basename "$1")"
+		return 1
+	fi
+	log_message "DSperate: unpacked $(basename "$1") to the card"
+	echo "$_out"
 }
 
 run_dsperate() {
@@ -105,6 +152,14 @@ run_dsperate() {
 
 	seed_dsperate_config
 
+	if ! _rom="$(prepare_dsperate_rom "$ROM_FILE")"; then
+		start_pyui_message_writer
+		log_and_display_message "Could not unpack $(basename "$ROM_FILE")."
+		sleep 4
+		stop_pyui_message_writer
+		return 1
+	fi
+
 	cd "$EMU_DIR"
 	/mnt/SDCARD/spruce/scripts/asound-setup.sh "$HOME"
 
@@ -119,18 +174,19 @@ run_dsperate() {
 	# The BIOS paths are in spruce.ini too, but pass them anyway: they are what
 	# dsperate_bios_missing just checked for, and a card upgraded from a config
 	# seeded before spruce.ini existed has no [paths] block at all.
-	set -- "$ROM_FILE" \
+	set -- "$_rom" \
 		--bios9 "$DSPERATE_BIOS_DIR/bios9.bin" \
 		--bios7 "$DSPERATE_BIOS_DIR/bios7.bin" \
 		--firmware "$DSPERATE_BIOS_DIR/firmware.bin" \
 		--fullscreen
 
-	_state="$(get_state_path "$ROM_FILE")"
+	_state="$(get_state_path "$_rom")"
 	if [ -n "$_state" ] && [ -f "$_state" ] && is_autoload_enabled; then
 		set -- "$@" --load-state "$_state"
 	fi
 
 	./dsperate "$@" > "$(emu_log_file)" 2>&1
 
+	rm -rf "$DSPERATE_TMP_DIR"
 	sync
 }

--- a/spruce/scripts/emu/lib/dsperate_functions.sh
+++ b/spruce/scripts/emu/lib/dsperate_functions.sh
@@ -49,31 +49,44 @@ seed_dsperate_config() {
 	fi
 }
 
-
 # returns 0=true or 1=false; for now, no per-game override logic in place.
 is_autoload_enabled() {
-    autoload_setting="$(jq -r '.menuOptions.dsperateAutoLoad.selected' "/mnt/SDCARD/Emu/NDS/config.json")"
-    if [ "$autoload_setting" = "Enabled" ]; then
-		return 0
-	else
-		return 1
-	fi
+	_setting="$(jq -r '.menuOptions.dsperateAutoLoad.selected // "Enabled"' "${EMU_JSON_PATH:-/mnt/SDCARD/Emu/NDS/config.json}")"
+	[ "$_setting" = "Enabled" ]
 }
 
+# The NDS header carries a four-character game code at offset 12, and DSperate
+# names the auto slot after it, so the launcher has to read it the same way to
+# know which file to resume from. 7zr cannot open a .rar and neither can
+# python's zipfile, so those come back empty rather than wrong.
 get_game_code() {
 	case "$1" in
-		*.nds|*.NDS)
-			dd if="$1" bs=1 skip=12 count=4 2>/dev/null
-			;;
-		*.zip|*.ZIP)
-			unzip -p "$1" '*.nds' | dd bs=1 skip=12 count=4 2>/dev/null
-			;;
+	*.nds | *.NDS)
+		dd if="$1" bs=1 skip=12 count=4 2>/dev/null
+		;;
+	*.zip | *.ZIP)
+		"$(get_python_path)" -c "
+import sys, zipfile
+with zipfile.ZipFile(sys.argv[1]) as z:
+    for name in z.namelist():
+        if name.lower().endswith('.nds'):
+            sys.stdout.write(z.open(name).read(16)[12:16].decode('latin-1'))
+            break
+" "$1" 2>/dev/null
+		;;
+	*.7z | *.7Z)
+		7zr e "$1" -so 2>/dev/null | dd bs=1 skip=12 count=4 2>/dev/null
+		;;
 	esac
-	echo
 }
 
+# Empty when the code cannot be read: a .rar, an archive with no .nds inside,
+# or a header full of junk. The caller has to check, because falling back to a
+# bare ".auto.dss" would be both a path DSperate never writes and one every
+# game would share.
 get_state_path() {
-	_code=$(get_game_code "$1")
+	_code="$(get_game_code "$1" | tr -dc 'A-Za-z0-9#_-')"
+	[ -n "$_code" ] || return 0
 	echo "/mnt/SDCARD/Saves/states/dsperate/${_code}.auto.dss"
 }
 
@@ -103,18 +116,21 @@ run_dsperate() {
 	# to go anyway.
 	[ "$VERBOSE_EMU" = "1" ] && export DS_FPS=1
 
-	state_path="$(get_state_path "$ROM_FILE")"
+	# The BIOS paths are in spruce.ini too, but pass them anyway: they are what
+	# dsperate_bios_missing just checked for, and a card upgraded from a config
+	# seeded before spruce.ini existed has no [paths] block at all.
+	set -- "$ROM_FILE" \
+		--bios9 "$DSPERATE_BIOS_DIR/bios9.bin" \
+		--bios7 "$DSPERATE_BIOS_DIR/bios7.bin" \
+		--firmware "$DSPERATE_BIOS_DIR/firmware.bin" \
+		--fullscreen
 
-	if is_autoload_enabled && [ -f "$state_path" ]; then
-		./dsperate "$ROM_FILE" \
-			--fullscreen \
-			--load-state "$state_path" \
-			> "$(emu_log_file)" 2>&1
-	else
-		./dsperate "$ROM_FILE" \
-			--fullscreen \
-			> "$(emu_log_file)" 2>&1
+	_state="$(get_state_path "$ROM_FILE")"
+	if [ -n "$_state" ] && [ -f "$_state" ] && is_autoload_enabled; then
+		set -- "$@" --load-state "$_state"
 	fi
+
+	./dsperate "$@" > "$(emu_log_file)" 2>&1
 
 	sync
 }

--- a/spruce/scripts/emu/lib/general_functions.sh
+++ b/spruce/scripts/emu/lib/general_functions.sh
@@ -185,7 +185,7 @@ set_cpu_mode() {
 
 pin_to_dedicated_cores() {
 	comm="$1"
-	delay="$2:-1"
+	delay="${2:-1}"
 
     # get the last two cores that are online
     EMU_CPUS=${DEVICE_MAX_CORES_ONLINE#"${DEVICE_MAX_CORES_ONLINE%??}"}

--- a/spruce/scripts/tasks/resetDSperate.sh
+++ b/spruce/scripts/tasks/resetDSperate.sh
@@ -2,8 +2,14 @@
 
 . /mnt/SDCARD/spruce/scripts/helperFunctions.sh
 
-if rm -rf /mnt/SDCARD/Saves/dsperate; then
-    log_message "dsperate configs have been reset."
+# The live config is under XDG_CONFIG_HOME, which run_dsperate points at
+# /mnt/SDCARD/Saves. Emu/NDS/config is where it used to live, so clear that too
+# or an upgraded card keeps a stale copy nobody reads. Saves and states are
+# deliberately left alone.
+rm -rf /mnt/SDCARD/Saves/dsperate /mnt/SDCARD/Emu/NDS/config
+
+if [ -d /mnt/SDCARD/Saves/dsperate ]; then
+	log_message "dsperate config nuke failed?"
 else
-    log_message "dsperate config nuke failed?"
+	log_message "dsperate configs have been reset."
 fi

--- a/spruce/scripts/tasks/resetDSperate.sh
+++ b/spruce/scripts/tasks/resetDSperate.sh
@@ -3,10 +3,9 @@
 . /mnt/SDCARD/spruce/scripts/helperFunctions.sh
 
 # The live config is under XDG_CONFIG_HOME, which run_dsperate points at
-# /mnt/SDCARD/Saves. Emu/NDS/config is where it used to live, so clear that too
-# or an upgraded card keeps a stale copy nobody reads. Saves and states are
-# deliberately left alone.
-rm -rf /mnt/SDCARD/Saves/dsperate /mnt/SDCARD/Emu/NDS/config
+# /mnt/SDCARD/Saves. Saves and states are deliberately left alone, and so is
+# Emu/NDS/config -- that is DraStic's, not ours.
+rm -rf /mnt/SDCARD/Saves/dsperate
 
 if [ -d /mnt/SDCARD/Saves/dsperate ]; then
 	log_message "dsperate config nuke failed?"


### PR DESCRIPTION
Review follow-ups on the DSperate series (`9ff7f6734..f4a38876e`). Nothing here changes the design, it just closes gaps in it.

## The two that matter

**`kill_emulator` never reaches `kill_dsperate`.** `f4a38876e` renamed the binary inside `kill_dsperate()` but not in the branch that decides to call it:

```sh
elif pgrep dsperate-sdl >/dev/null; then   # never matches now
```

So a power or menu longpress fell through to `kill_ra_and_standard_emulators`, which doesn't list DSperate — meaning no SIGTERM, and both the battery save and the `autosave = true` state are lost. Exactly what that commit was trying to protect.

**`pin_to_dedicated_cores` is still broken.** `6f1faa1ed` quoted the `EMU_CPUS` line, but the defect is one line up and untouched:

```sh
delay="$2:-1"      # a literal, not ${2:-1}
```

`sleep :-1` / `sleep 2:-1` both fail, so the backgrounded `pgrep` runs before the emulator exists and nothing gets pinned. DSperate no longer calls this, but RetroArch (no `$2`) and DraStic (`2`) still do.

## Auto-resume path handling

`get_game_code` covered `.nds` and `.zip`, but NDS `extlist` is `nds|zip|7z|rar`. An unreadable header gave an empty code and `get_state_path` returned a bare `.auto.dss` — a path DSperate never writes, and one every game would share.

- `.7z` now goes through `7zr e -so`, `.zip` through python's `zipfile`, matching how `mupen_functions.sh` and `bigpemu_functions.sh` already open archives. `unzip` isn't in `spruce/bin` and was used nowhere else in the tree, so the old `.zip` branch was relying on the busybox applet being present.
- `get_state_path` returns empty when no code comes back, and `run_dsperate` checks before adding `--load-state`. `.rar` has no reader available either way, so it now skips the resume cleanly instead of pointing at a shared name.

Verified locally against a synthetic ROM in all four shapes:

```
game.nds   code=[ABCD] state=[.../ABCD.auto.dss]
game.zip   code=[ABCD] state=[.../ABCD.auto.dss]
game.7z    code=[ABCD] state=[.../ABCD.auto.dss]
junk.rar   code=[]     state=[]
```

## Smaller things

- `is_autoload_enabled` read a hardcoded config path with no fallback. Now uses the exported `EMU_JSON_PATH` with `// "Enabled"`. (`get_config_value` is *not* right here — it reads `spruce-config.json`, not the per-emu one.)
- `dsperateAutoLoad` was missing the `"overrides": {}` every sibling in that block has.
- BIOS paths go back on the command line. They're in `spruce.ini`, but they're also what `dsperate_bios_missing` just checked for, and a card seeded during the mid-series nightlies (after `XDG_CONFIG_HOME` moved to `/mnt/SDCARD/Saves`, before `spruce.ini` landed) has an ini with no `[paths]` block — the BIOS check passes and then DSperate can't find them. Flags override the file, so this makes the checked files the used files. The two near-identical invocations collapse into one `set --` build-up.
- `resetDSperate.sh` trusted `rm -rf`'s exit status, which is 0 whether or not anything was there, so the failure branch was dead. It now checks the directory is gone, and also clears the orphaned `Emu/NDS/config` tree from the old XDG path. Saves and states are left alone.

## Not touched

Collapsing `Emulator_BrickPro` into `Emulator_SmartPro` drops `DraStic-Steward` from the Brick Pro's options and adds `DraStic-trngaje`. That reads as intentional per `efbcd8023`, so I left it — just flagging it.

## Testing

`sh -n` clean on all four scripts, `jq -e .` clean on the config. The game-code paths are hardware-independent and tested above. The `kill_dsperate` and pinning fixes want a device check.