### PR TITLE
[Miyoo Flip] Boot ports from second sd card

### DIFF
--- a/App/PortMaster/control.txt
+++ b/App/PortMaster/control.txt
@@ -8,7 +8,8 @@ CUR_TTY=/dev/null
 
 if [ -d "/mnt/SDCARD/spruce" ]; then
   export controlfolder="/mnt/SDCARD/Persistent/portmaster/PortMaster"
-  export directory="/mnt/SDCARD/Roms/PORTS/"
+  directory="${PORTS_DIR:-/mnt/SDCARD/Roms/PORTS}"
+	export directory="${directory%/}/"
   # Ports reach pugwash and harbourmaster through PortMasterDialog.txt, which
   # is upstream's file and runs "$controlfolder/pugwash" as-is, so its
   # "#!/usr/bin/env python3" is resolved by PATH. The bundled interpreter has

--- a/Saves/flip/home/.local/share/PortMaster/control.txt
+++ b/Saves/flip/home/.local/share/PortMaster/control.txt
@@ -8,7 +8,8 @@ CUR_TTY=/dev/null
 
 if [ -d "/mnt/SDCARD/spruce" ]; then
   export controlfolder="/mnt/SDCARD/Persistent/portmaster/PortMaster"
-  export directory="/mnt/SDCARD/Roms/PORTS/"
+  directory="${PORTS_DIR:-/mnt/SDCARD/Roms/PORTS}"
+	export directory="${directory%/}/"
   export PATH="/mnt/SDCARD/Persistent/portmaster/bin:$PATH"
   export LD_LIBRARY_PATH="/mnt/SDCARD/Persistent/portmaster/lib:$LD_LIBRARY_PATH"
 else

--- a/spruce/scripts/emu/lib/ports_functions.sh
+++ b/spruce/scripts/emu/lib/ports_functions.sh
@@ -20,7 +20,7 @@ extract_game_dir(){
     # If gamedir_name ends with a slash, remove the slash
     gamedir_line="${gamedir_line%/}"
     # Extract everything after the last '/' in the GAMEDIR line and assign it to game_dir
-    game_dir="/mnt/SDCARD/Roms/PORTS/${gamedir_line##*/}"
+    game_dir="${PORTS_DIR:-/mnt/SDCARD/Roms/PORTS}/${gamedir_line##*/}"
     # If game_dir ends with a quote, remove the quote
     echo "${game_dir%\"}"
 }
@@ -69,12 +69,65 @@ set_port_abxy_scheme() {
     fi
 }
 
+portmaster_mount_is_active() {
+    awk -v target="$1" '
+        $2 == target {
+            found = 1
+        }
+        END {
+            exit(found ? 0 : 1)
+        }
+    ' /proc/mounts
+}
+
+portmaster_cleanup_dynamic_bind() {
+    if [ "$PORTS_BIND_CREATED" = "true" ]; then
+        if umount "$PORTS_BIND_TARGET"; then
+            log_message "Dual SD: removed bind from $PORTS_BIND_TARGET"
+            PORTS_BIND_CREATED=false
+        else
+            log_message "Dual SD: could not unmount $PORTS_BIND_TARGET"
+        fi
+    fi
+}
+
 run_port() {
     log_message "Running port on $PLATFORM w/ ($PLATFORM_ARCHITECTURE)"
+
+    #
+    # PortMaster launchers expect:
+    #
+    #   $PORTS_DIR/ports/game
+    #
+    # The actual game folders are directly inside PORTS, so reproduce
+    # spruce's PORTS -> PORTS/ports compatibility bind when necessary.
+    #
+    PORTS_BIND_TARGET="$PORTS_DIR/ports"
+    PORTS_BIND_CREATED=false
+
+    mkdir -p "$PORTS_BIND_TARGET"
+
+    if portmaster_mount_is_active "$PORTS_BIND_TARGET"; then
+        log_message "PortMaster compatibility bind already active: $PORTS_BIND_TARGET"
+    else
+        if mount --bind "$PORTS_DIR" "$PORTS_BIND_TARGET"; then
+            PORTS_BIND_CREATED=true
+            log_message "Dual SD: mounted $PORTS_DIR on $PORTS_BIND_TARGET"
+        else
+            log_message "Dual SD: failed to mount $PORTS_DIR on $PORTS_BIND_TARGET"
+            return 1
+        fi
+    fi
+
+    #
+    # Attempt cleanup when the launcher exits or receives a normal signal.
+    #
+    trap 'portmaster_cleanup_dynamic_bind' EXIT
+    trap 'portmaster_cleanup_dynamic_bind; exit 1' HUP INT TERM
+	
     device_prepare_for_ports_run
 
     # Setup variables
-    PORTS_DIR=/mnt/SDCARD/Roms/PORTS
     export HOME="/mnt/SDCARD/Saves/flip/home"
     export LD_LIBRARY_PATH="$PORTS_LD_LIBRARY_PATH:$LD_LIBRARY_PATH"
 	export LC_ALL=C
@@ -93,10 +146,16 @@ run_port() {
     if [ $? -eq 1 ]; then
         log_message "Launching RA port $ROM_FILE"
         cd /mnt/SDCARD/RetroArch/
-        "$ROM_FILE" > /mnt/SDCARD/Saves/spruce/port.log 2>&1 &
+		"$ROM_FILE" &> /mnt/SDCARD/Saves/spruce/port.log &
+        SID=$!
+        echo "$SID" > /tmp/last_port_sid
+        wait "$SID"
+        rm -f /tmp/last_port_sid
     else
         if [ "$MOUNT_BIND" = true ]; then
-            mount --bind /mnt/SDCARD/Persistent/portmaster/bin/python3.10 /mnt/SDCARD/Persistent/portmaster/bin/python
+            mount --bind \
+                /mnt/SDCARD/Persistent/portmaster/bin/python3.10 \
+                /mnt/SDCARD/Persistent/portmaster/bin/python
         fi
 
         log_message "PORTS_DIR: $PORTS_DIR, HOME=$HOME, LD_LIBRARY_PATH=$LD_LIBRARY_PATH, PATH=$PATH"
@@ -114,6 +173,9 @@ run_port() {
         wait "$SID"
         rm -f /tmp/last_port_sid
     fi
+
+	portmaster_cleanup_dynamic_bind
+    trap - EXIT HUP INT TERM
 
     device_cleanup_after_ports_run
 }


### PR DESCRIPTION
Here's my attempt to fix booting ports from second sd slot in Miyoo Flip devices. I only tested this myself on my Flip with Spruce 4.3.4 running.

When modifying files in Development branch I found the files were a bit different from what I encountered on 4.3.4, so maybe this won't work as intended.

Since Spruce already lists ports in sd card slot 2, what I did here was to use whatever rom path the system receives to mount portmaster's bind and stuff. Also, I tried to protect this binding for proper removal if the port would suffer a crash or a non clean exit.

Maybe the code can be improved, cleaned, or maybe I touched the wrong files. All I can say is that it works for me, I tried a bunch of ports and all of them booted fine.