### PR TITLE
Add low battery warning display and handling

### DIFF
--- a/spruce/scripts/low_power_warning.sh
+++ b/spruce/scripts/low_power_warning.sh
@@ -71,6 +71,58 @@ init_battery_log() {
     fi
 }
 
+show_low_battery_warning() {
+    display -t "Battery has $CAPACITY% left. Charge or shutdown your device." \
+        --add-image "/mnt/SDCARD/spruce/imgs/displayAcknowledge.png" 1.0 240 middle
+
+    /mnt/SDCARD/spruce/flip/bin/python3 - <<'PY'
+import os
+import fcntl
+import struct
+
+DEVICE = "/dev/input/event5"
+A_BUTTON = 305
+EVIOCGRAB = 0x40044590
+
+fmt = "llHHi"
+size = struct.calcsize(fmt)
+
+fd = os.open(DEVICE, os.O_RDONLY)
+
+try:
+    fcntl.ioctl(fd, EVIOCGRAB, 1)
+
+    while True:
+        data = os.read(fd, size)
+        if len(data) != size:
+            continue
+
+        _, _, ev_type, code, value = struct.unpack(fmt, data)
+
+        if ev_type == 1 and code == A_BUTTON and value == 1:
+
+            while True:
+                data = os.read(fd, size)
+                if len(data) != size:
+                    continue
+
+                _, _, ev_type, code, value = struct.unpack(fmt, data)
+
+                if ev_type == 1 and code == A_BUTTON and value == 0:
+                    break
+
+            break
+
+finally:
+    fcntl.ioctl(fd, EVIOCGRAB, 0)
+    os.close(fd)
+PY
+
+    display_kill
+    sleep 0.5
+    killall -USR1 MainUI 2>/dev/null
+}
+
 hard_shutdown() {
     CAPACITY=$1
     if [ "$CAPACITY" -le 1 ] 2>/dev/null; then
@@ -129,10 +181,14 @@ while true; do
             else
                 if [ "$flag_added" = false ]; then
                     if flag_check "in_menu"; then
-                        display -t "Battery has $CAPACITY% left. Charge or shutdown your device." --okay
-                    else
-                        flag_add "low_battery" --tmp
-                    fi
+                        if [ "$PLATFORM" = "Flip" ]; then
+							show_low_battery_warning
+						else
+							display -t "Battery has $CAPACITY% left. Charge or shutdown your device." --okay
+						fi
+					else
+						flag_add "low_battery" --tmp
+					fi
                     flag_added=true
                 fi
                 morse_code_sos "false" "." "." "." "-" "-" "-" "." "." "."


### PR DESCRIPTION
Here's my attempt to fix low battery warning making the screen black when the user accepts the message, at least on Flip devices. I tested this myself on my Flip with Spruce 4.3.4 running.

Also, I made pressing A to dismiss not perform an A press action on whatever screen behing the warning message.

Maybe the code can be improved, cleaned, or maybe I touched the wrong files. All I can say is that it works for me. Feel free to change the code or close the PR and make your own fix :)